### PR TITLE
feat: #2 tasks 테이블 정의 + 첫 마이그레이션 (TDD RED→GREEN)

### DIFF
--- a/drizzle/0000_redundant_the_twelve.sql
+++ b/drizzle/0000_redundant_the_twelve.sql
@@ -1,0 +1,21 @@
+CREATE TABLE IF NOT EXISTS "tasks" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"parent_id" uuid,
+	"title" text NOT NULL,
+	"description" text,
+	"assignee" text,
+	"status" text DEFAULT 'todo' NOT NULL,
+	"progress" integer DEFAULT 0 NOT NULL,
+	"start_date" date,
+	"due_date" date,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL,
+	CONSTRAINT "tasks_status_check" CHECK ("tasks"."status" in ('todo','doing','done')),
+	CONSTRAINT "tasks_progress_check" CHECK ("tasks"."progress" between 0 and 100)
+);
+--> statement-breakpoint
+DO $$ BEGIN
+ ALTER TABLE "tasks" ADD CONSTRAINT "tasks_parent_id_tasks_id_fk" FOREIGN KEY ("parent_id") REFERENCES "public"."tasks"("id") ON DELETE cascade ON UPDATE no action;
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;

--- a/drizzle/meta/0000_snapshot.json
+++ b/drizzle/meta/0000_snapshot.json
@@ -1,0 +1,126 @@
+{
+  "id": "db927ea4-c72d-4a47-9d87-751c2b5c3fb3",
+  "prevId": "00000000-0000-0000-0000-000000000000",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.tasks": {
+      "name": "tasks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "assignee": {
+          "name": "assignee",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'todo'"
+        },
+        "progress": {
+          "name": "progress",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "start_date": {
+          "name": "start_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "due_date": {
+          "name": "due_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "tasks_parent_id_tasks_id_fk": {
+          "name": "tasks_parent_id_tasks_id_fk",
+          "tableFrom": "tasks",
+          "tableTo": "tasks",
+          "columnsFrom": [
+            "parent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "tasks_status_check": {
+          "name": "tasks_status_check",
+          "value": "\"tasks\".\"status\" in ('todo','doing','done')"
+        },
+        "tasks_progress_check": {
+          "name": "tasks_progress_check",
+          "value": "\"tasks\".\"progress\" between 0 and 100"
+        }
+      },
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -1,1 +1,13 @@
-{"version":"7","dialect":"postgresql","entries":[]}
+{
+  "version": "7",
+  "dialect": "postgresql",
+  "entries": [
+    {
+      "idx": 0,
+      "version": "7",
+      "when": 1777014126076,
+      "tag": "0000_redundant_the_twelve",
+      "breakpoints": true
+    }
+  ]
+}

--- a/lib/db/schema.ts
+++ b/lib/db/schema.ts
@@ -1,2 +1,23 @@
-// tasks 테이블 정의는 이후 이슈에서 CLAUDE.md §3 의 스펙대로 추가한다.
-export {};
+import { pgTable, uuid, text, integer, date, timestamp, check } from 'drizzle-orm/pg-core';
+import { sql } from 'drizzle-orm';
+
+export const tasks = pgTable(
+  'tasks',
+  {
+    id: uuid('id').primaryKey().defaultRandom(),
+    parentId: uuid('parent_id').references((): any => tasks.id, { onDelete: 'cascade' }),
+    title: text('title').notNull(),
+    description: text('description'),
+    assignee: text('assignee'),
+    status: text('status').notNull().default('todo'),
+    progress: integer('progress').notNull().default(0),
+    startDate: date('start_date'),
+    dueDate: date('due_date'),
+    createdAt: timestamp('created_at', { withTimezone: true }).notNull().defaultNow(),
+    updatedAt: timestamp('updated_at', { withTimezone: true }).notNull().defaultNow(),
+  },
+  (t) => ({
+    statusCheck: check('tasks_status_check', sql`${t.status} in ('todo','doing','done')`),
+    progressCheck: check('tasks_progress_check', sql`${t.progress} between 0 and 100`),
+  }),
+);

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "lint": "next lint",
     "test": "vitest run",
     "test:watch": "vitest",
+    "test:integration": "vitest run --config vitest.integration.config.ts",
     "test:e2e": "playwright test",
     "test:e2e:ui": "playwright test --ui",
     "db:generate": "drizzle-kit generate",

--- a/tests/integration/db/tasks.schema.test.ts
+++ b/tests/integration/db/tasks.schema.test.ts
@@ -1,0 +1,177 @@
+/**
+ * tasks 테이블 스키마 RED 테스트 (Issue #2).
+ *
+ * 근거: SPEC.md §1 A-2·A-3, §2 B-2, §4 D-2, §5 E-1, §8 H-1.
+ * 각 테스트는 실제 로컬 Supabase Postgres 에 연결해 tasks 테이블의 제약·기본값·FK 를 검증한다.
+ * 이 시점에는 tasks 테이블이 아직 존재하지 않으므로 전 테스트가 실패해야 정상 (RED).
+ */
+import { describe, it, expect, beforeAll, afterAll, beforeEach } from 'vitest';
+import postgres from 'postgres';
+
+const connectionString = process.env.DATABASE_URL!;
+let sql: ReturnType<typeof postgres>;
+
+beforeAll(() => {
+  sql = postgres(connectionString, { prepare: false, max: 1, onnotice: () => {} });
+});
+
+afterAll(async () => {
+  await sql.end();
+});
+
+beforeEach(async () => {
+  await sql`TRUNCATE tasks RESTART IDENTITY CASCADE`;
+});
+
+describe('tasks 테이블 스키마', () => {
+  describe('해피 패스', () => {
+    it('title 만 있는 insert → 성공, status=todo, progress=0, id·created_at·updated_at 자동 세팅', async () => {
+      const [row] = await sql`
+        INSERT INTO tasks (title) VALUES ('킥오프 미팅') RETURNING *
+      `;
+      expect(row.title).toBe('킥오프 미팅');
+      expect(row.status).toBe('todo');
+      expect(row.progress).toBe(0);
+      expect(row.id).toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/);
+      expect(row.created_at).toBeInstanceOf(Date);
+      expect(row.updated_at).toBeInstanceOf(Date);
+    });
+
+    it('모든 컬럼을 채운 insert → SELECT 결과가 입력과 일치', async () => {
+      const [row] = await sql`
+        INSERT INTO tasks (title, description, assignee, status, progress, start_date, due_date)
+        VALUES ('리서치', '시장 리서치', '김PM', 'doing', 45, '2026-05-01', '2026-05-14')
+        RETURNING *
+      `;
+      expect(row).toMatchObject({
+        title: '리서치',
+        description: '시장 리서치',
+        assignee: '김PM',
+        status: 'doing',
+        progress: 45,
+      });
+      expect(row.start_date).not.toBeNull();
+      expect(row.due_date).not.toBeNull();
+    });
+  });
+
+  describe('NOT NULL / CHECK 제약', () => {
+    it('title 생략 → insert 실패 (NOT NULL)', async () => {
+      await expect(sql`INSERT INTO tasks DEFAULT VALUES`).rejects.toThrow();
+    });
+
+    it("status='blocked' 같은 허용 외 값 → insert 실패 (CHECK)", async () => {
+      await expect(
+        sql`INSERT INTO tasks (title, status) VALUES ('X', 'blocked')`,
+      ).rejects.toThrow();
+    });
+
+    it('progress = -1 → insert 실패 (CHECK)', async () => {
+      await expect(
+        sql`INSERT INTO tasks (title, progress) VALUES ('X', -1)`,
+      ).rejects.toThrow();
+    });
+
+    it('progress = 101 → insert 실패 (CHECK)', async () => {
+      await expect(
+        sql`INSERT INTO tasks (title, progress) VALUES ('X', 101)`,
+      ).rejects.toThrow();
+    });
+
+    it('경계값 progress = 0 / 100 → insert 성공', async () => {
+      const [zero] = await sql`
+        INSERT INTO tasks (title, progress) VALUES ('Z', 0) RETURNING progress
+      `;
+      const [hundred] = await sql`
+        INSERT INTO tasks (title, progress) VALUES ('H', 100) RETURNING progress
+      `;
+      expect(zero.progress).toBe(0);
+      expect(hundred.progress).toBe(100);
+    });
+  });
+
+  describe('FK · 계층 (parent_id)', () => {
+    it('parent_id = null → 최상위 task 성공', async () => {
+      const [row] = await sql`
+        INSERT INTO tasks (title, parent_id) VALUES ('최상위', NULL) RETURNING parent_id
+      `;
+      expect(row.parent_id).toBeNull();
+    });
+
+    it('부모 insert 후 자식 insert → 자식의 parent_id 가 부모 id 로 연결', async () => {
+      const [parent] = await sql`INSERT INTO tasks (title) VALUES ('부모') RETURNING id`;
+      const [child] = await sql`
+        INSERT INTO tasks (title, parent_id) VALUES ('자식', ${parent.id}) RETURNING parent_id
+      `;
+      expect(child.parent_id).toBe(parent.id);
+    });
+
+    it('존재하지 않는 UUID 를 parent_id 로 → insert 실패 (FK)', async () => {
+      await expect(
+        sql`INSERT INTO tasks (title, parent_id) VALUES ('X', '00000000-0000-0000-0000-000000000000'::uuid)`,
+      ).rejects.toThrow();
+    });
+
+    it('부모 삭제 → 자식도 자동 삭제 (ON DELETE CASCADE, SPEC.md D-2)', async () => {
+      const [parent] = await sql`INSERT INTO tasks (title) VALUES ('P') RETURNING id`;
+      await sql`INSERT INTO tasks (title, parent_id) VALUES ('C1', ${parent.id})`;
+      await sql`INSERT INTO tasks (title, parent_id) VALUES ('C2', ${parent.id})`;
+      await sql`DELETE FROM tasks WHERE id = ${parent.id}`;
+      const rows = await sql`SELECT id FROM tasks`;
+      expect(rows).toHaveLength(0);
+    });
+
+    it('3단계(부모→자식→손주) 에서도 위에서부터 cascade', async () => {
+      const [p] = await sql`INSERT INTO tasks (title) VALUES ('P') RETURNING id`;
+      const [c] = await sql`
+        INSERT INTO tasks (title, parent_id) VALUES ('C', ${p.id}) RETURNING id
+      `;
+      await sql`INSERT INTO tasks (title, parent_id) VALUES ('G', ${c.id})`;
+      await sql`DELETE FROM tasks WHERE id = ${p.id}`;
+      const rows = await sql`SELECT id FROM tasks`;
+      expect(rows).toHaveLength(0);
+    });
+  });
+
+  describe('정렬 / 시간', () => {
+    it('여러 task 시간차 insert 후 ORDER BY created_at ASC → 입력 순서와 동일 (SPEC.md A-3)', async () => {
+      await sql`INSERT INTO tasks (title) VALUES ('첫째')`;
+      await new Promise((r) => setTimeout(r, 10));
+      await sql`INSERT INTO tasks (title) VALUES ('둘째')`;
+      await new Promise((r) => setTimeout(r, 10));
+      await sql`INSERT INTO tasks (title) VALUES ('셋째')`;
+      const rows = await sql<{ title: string }[]>`
+        SELECT title FROM tasks ORDER BY created_at ASC
+      `;
+      expect(rows.map((r) => r.title)).toEqual(['첫째', '둘째', '셋째']);
+    });
+  });
+
+  describe('날짜 nullable (SPEC.md A-2)', () => {
+    it('start_date 만 있고 due_date 없음 → 저장 성공', async () => {
+      const [row] = await sql`
+        INSERT INTO tasks (title, start_date) VALUES ('X', '2026-05-01')
+        RETURNING start_date, due_date
+      `;
+      expect(row.start_date).not.toBeNull();
+      expect(row.due_date).toBeNull();
+    });
+
+    it('due_date 만 있고 start_date 없음 → 저장 성공', async () => {
+      const [row] = await sql`
+        INSERT INTO tasks (title, due_date) VALUES ('X', '2026-05-14')
+        RETURNING start_date, due_date
+      `;
+      expect(row.start_date).toBeNull();
+      expect(row.due_date).not.toBeNull();
+    });
+
+    it('둘 다 없음 → 저장 성공', async () => {
+      const [row] = await sql`
+        INSERT INTO tasks (title) VALUES ('X') RETURNING start_date, due_date
+      `;
+      expect(row.start_date).toBeNull();
+      expect(row.due_date).toBeNull();
+    });
+  });
+});

--- a/tests/integration/setup.ts
+++ b/tests/integration/setup.ts
@@ -1,0 +1,9 @@
+import { config } from 'dotenv';
+
+config({ path: '.env.local' });
+
+if (!process.env.DATABASE_URL) {
+  throw new Error(
+    '통합 테스트에는 DATABASE_URL 이 필요합니다. 로컬 Supabase 컨테이너(`supabase start`)를 띄우고 `.env.local` 에 DATABASE_URL 을 설정하세요.',
+  );
+}

--- a/vitest.integration.config.ts
+++ b/vitest.integration.config.ts
@@ -1,19 +1,18 @@
 import { defineConfig } from 'vitest/config';
-import react from '@vitejs/plugin-react';
 import { fileURLToPath } from 'node:url';
 
 export default defineConfig({
-  plugins: [react()],
   resolve: {
     alias: {
       '@': fileURLToPath(new URL('.', import.meta.url)),
     },
   },
   test: {
-    environment: 'jsdom',
+    environment: 'node',
     globals: true,
-    setupFiles: ['./vitest.setup.ts'],
-    include: ['**/*.test.{ts,tsx}'],
-    exclude: ['node_modules', '.next', 'tests/e2e/**', 'tests/integration/**'],
+    setupFiles: ['./tests/integration/setup.ts'],
+    include: ['tests/integration/**/*.test.ts'],
+    fileParallelism: false,
+    testTimeout: 15000,
   },
 });


### PR DESCRIPTION
## Summary
- SPEC.md §1·§2·§4·§5·§8 의 사용자 요구를 `tasks` 테이블 하나로 번역. CRUD·UI·비즈니스 규칙은 후속 이슈.
- **TDD 사이클 2커밋**:
  - `b4de7bd` (RED) — 통합 테스트 16건 추가, 전부 실패 확인
  - `354e22d` (GREEN) — `lib/db/schema.ts` + `drizzle/0000_*.sql` 로 전부 통과
- 통합 테스트 러너를 유닛과 분리(`npm run test:integration`) — CI 통합은 후속 이슈(앱 기동·DB 준비 필요).

## 구현 상세
- **Schema** (`lib/db/schema.ts`): CLAUDE.md §3 Drizzle DSL 그대로
  - 11 columns, CHECK 2개 (status, progress), FK 1개 (parent_id → tasks.id ON DELETE CASCADE)
- **Migration**: `drizzle/0000_redundant_the_twelve.sql` — `drizzle-kit generate` 산출, 수기 편집 없음
- **Integration harness**: `tests/integration/setup.ts` (dotenv + DATABASE_URL 가드), `vitest.integration.config.ts` (node env, fileParallelism: false), `beforeEach` 에서 `TRUNCATE tasks RESTART IDENTITY CASCADE`

## Test plan
- [x] `npm run test:integration` — 16 passed (해피패스 2 · NOT NULL/CHECK 5 · FK/계층 5 · 정렬 1 · 날짜 nullable 3)
- [x] `npm test` (유닛) — 2 passed, 회귀 없음
- [x] `npx tsc --noEmit` — 타입 에러 없음
- [x] `npm run lint` — 경고·에러 없음
- [x] `npm run db:generate` — 생성된 SQL 리뷰 통과 (11 columns, 2 CHECK, 1 FK cascade)
- [x] `npm run db:migrate` — 로컬 Supabase 적용 성공
- [ ] merge 후 `.github/workflows/db-migrate.yml` 이 원격 Supabase 에 자동 적용 (PR 체크에는 안 잡히고 merge 이후 Actions 탭에서 확인)

## SPEC.md 매핑 (근거)
| SPEC.md 필드 | 컬럼 | 제약 | 근거 |
|---|---|---|---|
| 제목 | `title` | NOT NULL | B-2 |
| 상태 배지 | `status` | CHECK + default `'todo'` | A-2/C-2 |
| 진행률 | `progress` | CHECK 0-100 + default 0 | A-2/B-2 |
| 상위 작업 | `parent_id` | FK cascade | E-1/D-2 |
| 정렬 기준 | `created_at` | default now() | A-3 |
| 목표 기한 | `due_date` | nullable, 이름 고정 | A-2/H-1 |

## 후속 이슈로 미룬 것
- 상태 ↔ 진행률 자동 전환 (SPEC.md C-2) — 앱 로직 → #5
- 시작일 < 목표 기한 폼 검증 (SPEC.md B-2) → #5
- Overdue 판정 (SPEC.md §8) → #11
- 통합 테스트 CI job → 후속

Closes #2

🤖 Generated with [Claude Code](https://claude.com/claude-code)