### PR TITLE
feat: #4 Task 계층(부모-자식) 표시 및 들여쓰기 (TDD 4단계)

### DIFF
--- a/components/__tests__/task-list.test.tsx
+++ b/components/__tests__/task-list.test.tsx
@@ -68,4 +68,49 @@ describe('<TaskList />', () => {
     expect(onDeleteClick).toHaveBeenCalledWith(t);
     expect(onRowClick).not.toHaveBeenCalled();
   });
+
+  describe('트리 렌더 (Stage 2, SPEC §5 E)', () => {
+    it('입력이 뒤섞여도 DFS 순서로 렌더 (부모 → 자식)', () => {
+      const c = makeTask({ id: 'c', parentId: 'p', title: 'Child' });
+      const p = makeTask({ id: 'p', title: 'Parent' });
+      renderWithChakra(<TaskList tasks={[c, p]} onRowClick={vi.fn()} />);
+      const buttons = screen.getAllByRole('button', { name: /^작업:/ });
+      expect(buttons[0].getAttribute('aria-label')).toBe('작업: Parent');
+      expect(buttons[1].getAttribute('aria-label')).toBe('작업: Child');
+    });
+
+    it('깊이에 따른 data-depth 속성 (E-1 들여쓰기 근거)', () => {
+      const p = makeTask({ id: 'p', title: 'Parent' });
+      const c = makeTask({ id: 'c', parentId: 'p', title: 'Child' });
+      const g = makeTask({ id: 'g', parentId: 'c', title: 'Grandchild' });
+      renderWithChakra(<TaskList tasks={[p, c, g]} onRowClick={vi.fn()} />);
+      expect(screen.getByRole('button', { name: '작업: Parent' })).toHaveAttribute('data-depth', '0');
+      expect(screen.getByRole('button', { name: '작업: Child' })).toHaveAttribute('data-depth', '1');
+      expect(screen.getByRole('button', { name: '작업: Grandchild' })).toHaveAttribute('data-depth', '2');
+    });
+
+    it('자식 있는 행에 "▼" 아이콘 렌더 (E-2)', () => {
+      const p = makeTask({ id: 'p' });
+      const c = makeTask({ id: 'c', parentId: 'p' });
+      renderWithChakra(<TaskList tasks={[p, c]} onRowClick={vi.fn()} />);
+      expect(screen.getByText('▼')).toBeInTheDocument();
+    });
+
+    it('자식 없는 단일 행에는 ▼/▶ 아이콘 없음 (E-2)', () => {
+      const t = makeTask({ id: 'solo' });
+      renderWithChakra(<TaskList tasks={[t]} onRowClick={vi.fn()} />);
+      expect(screen.queryByText('▼')).toBeNull();
+      expect(screen.queryByText('▶')).toBeNull();
+    });
+
+    it('orphan parentId → root(depth=0) 로 렌더', () => {
+      const orphan = makeTask({
+        id: 'orphan',
+        parentId: '00000000-0000-0000-0000-000000000000',
+        title: 'Orphan',
+      });
+      renderWithChakra(<TaskList tasks={[orphan]} onRowClick={vi.fn()} />);
+      expect(screen.getByRole('button', { name: '작업: Orphan' })).toHaveAttribute('data-depth', '0');
+    });
+  });
 });

--- a/components/__tests__/task-list.test.tsx
+++ b/components/__tests__/task-list.test.tsx
@@ -113,4 +113,47 @@ describe('<TaskList />', () => {
       expect(screen.getByRole('button', { name: '작업: Orphan' })).toHaveAttribute('data-depth', '0');
     });
   });
+
+  describe('펼침/접힘 (Stage 3, SPEC §5 E-2)', () => {
+    it('접기 버튼 클릭 → ▶ 로 바뀌고 자식 숨김', () => {
+      const p = makeTask({ id: 'p', title: 'Parent' });
+      const c = makeTask({ id: 'c', parentId: 'p', title: 'Child' });
+      renderWithChakra(<TaskList tasks={[p, c]} onRowClick={vi.fn()} />);
+      fireEvent.click(screen.getByRole('button', { name: '접기' }));
+      expect(screen.queryByRole('button', { name: '작업: Child' })).toBeNull();
+      expect(screen.getByRole('button', { name: '펼치기' })).toBeInTheDocument();
+    });
+
+    it('펼치기 버튼 클릭 → ▼ 로 복원, 자식 다시 보임', () => {
+      const p = makeTask({ id: 'p', title: 'Parent' });
+      const c = makeTask({ id: 'c', parentId: 'p', title: 'Child' });
+      renderWithChakra(<TaskList tasks={[p, c]} onRowClick={vi.fn()} />);
+      fireEvent.click(screen.getByRole('button', { name: '접기' }));
+      fireEvent.click(screen.getByRole('button', { name: '펼치기' }));
+      expect(screen.getByRole('button', { name: '작업: Child' })).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: '접기' })).toBeInTheDocument();
+    });
+
+    it('토글 클릭은 onRowClick 호출 안 됨 (stopPropagation)', () => {
+      const p = makeTask({ id: 'p', title: 'Parent' });
+      const c = makeTask({ id: 'c', parentId: 'p', title: 'Child' });
+      const onRowClick = vi.fn();
+      renderWithChakra(<TaskList tasks={[p, c]} onRowClick={onRowClick} />);
+      fireEvent.click(screen.getByRole('button', { name: '접기' }));
+      expect(onRowClick).not.toHaveBeenCalled();
+    });
+
+    it('조부 접으면 자식과 손자 모두 사라짐', () => {
+      const p = makeTask({ id: 'p', title: 'Parent' });
+      const c = makeTask({ id: 'c', parentId: 'p', title: 'Child' });
+      const g = makeTask({ id: 'g', parentId: 'c', title: 'Grandchild' });
+      renderWithChakra(<TaskList tasks={[p, c, g]} onRowClick={vi.fn()} />);
+      // Parent 접기 버튼 (여러 개 중 Parent 의 것)
+      const parentRow = screen.getByRole('button', { name: '작업: Parent' });
+      const toggleInParentRow = parentRow.querySelector('button[aria-label="접기"]') as HTMLElement;
+      fireEvent.click(toggleInParentRow);
+      expect(screen.queryByRole('button', { name: '작업: Child' })).toBeNull();
+      expect(screen.queryByRole('button', { name: '작업: Grandchild' })).toBeNull();
+    });
+  });
 });

--- a/components/task-list.tsx
+++ b/components/task-list.tsx
@@ -1,7 +1,9 @@
 'use client';
 
+import { useMemo } from 'react';
 import { Box, Button, Flex, Stack, Text } from '@chakra-ui/react';
 import type { Task } from '@/lib/db/schema';
+import { buildTaskTree, type TaskNode } from '@/lib/tasks/build-tree';
 
 export type TaskListProps = {
   tasks: Task[];
@@ -10,8 +12,20 @@ export type TaskListProps = {
   onDeleteClick?: (task: Task) => void;
 };
 
+function flattenTree(nodes: TaskNode[]): TaskNode[] {
+  const out: TaskNode[] = [];
+  const walk = (n: TaskNode): void => {
+    out.push(n);
+    for (const child of n.children) walk(child);
+  };
+  for (const n of nodes) walk(n);
+  return out;
+}
+
 export function TaskList({ tasks, onRowClick, onAddChildClick, onDeleteClick }: TaskListProps) {
-  if (tasks.length === 0) {
+  const flatNodes = useMemo(() => flattenTree(buildTaskTree(tasks)), [tasks]);
+
+  if (flatNodes.length === 0) {
     return (
       <Box py={10} textAlign="center">
         <Text color="fg.muted">아직 작업이 없습니다. 첫 작업을 추가해 시작하세요</Text>
@@ -21,58 +35,65 @@ export function TaskList({ tasks, onRowClick, onAddChildClick, onDeleteClick }: 
 
   return (
     <Stack gap={2}>
-      {tasks.map((task) => (
-        <Box
-          key={task.id}
-          role="button"
-          aria-label={`작업: ${task.title}`}
-          tabIndex={0}
-          onClick={() => onRowClick(task)}
-          onKeyDown={(e) => {
-            if (e.key === 'Enter' || e.key === ' ') {
-              e.preventDefault();
-              onRowClick(task);
-            }
-          }}
-          cursor="pointer"
-          p={3}
-          borderWidth="1px"
-          borderRadius="md"
-          _hover={{ bg: 'bg.subtle' }}
-        >
-          <Flex gap={4} align="center">
-            <Text flex="1" fontWeight="medium">{task.title}</Text>
-            <Text color="fg.muted" minW="20">{task.assignee ?? '—'}</Text>
-            <Text fontSize="sm">{task.status}</Text>
-            <Text fontSize="sm" minW="12" textAlign="right">{task.progress}%</Text>
-            {onAddChildClick && (
-              <Button
-                size="xs"
-                variant="ghost"
-                onClick={(e) => {
-                  e.stopPropagation();
-                  onAddChildClick(task);
-                }}
-              >
-                + 하위
-              </Button>
-            )}
-            {onDeleteClick && (
-              <Button
-                size="xs"
-                variant="ghost"
-                colorPalette="red"
-                onClick={(e) => {
-                  e.stopPropagation();
-                  onDeleteClick(task);
-                }}
-              >
-                삭제
-              </Button>
-            )}
-          </Flex>
-        </Box>
-      ))}
+      {flatNodes.map((node) => {
+        const { task, depth, children } = node;
+        const hasChildren = children.length > 0;
+        return (
+          <Box
+            key={task.id}
+            role="button"
+            aria-label={`작업: ${task.title}`}
+            tabIndex={0}
+            data-depth={depth}
+            onClick={() => onRowClick(task)}
+            onKeyDown={(e) => {
+              if (e.key === 'Enter' || e.key === ' ') {
+                e.preventDefault();
+                onRowClick(task);
+              }
+            }}
+            cursor="pointer"
+            p={3}
+            pl={3 + depth * 6}
+            borderWidth="1px"
+            borderRadius="md"
+            _hover={{ bg: 'bg.subtle' }}
+          >
+            <Flex gap={4} align="center">
+              <Box minW={4}>{hasChildren && <Text as="span">▼</Text>}</Box>
+              <Text flex="1" fontWeight="medium">{task.title}</Text>
+              <Text color="fg.muted" minW="20">{task.assignee ?? '—'}</Text>
+              <Text fontSize="sm">{task.status}</Text>
+              <Text fontSize="sm" minW="12" textAlign="right">{task.progress}%</Text>
+              {onAddChildClick && (
+                <Button
+                  size="xs"
+                  variant="ghost"
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    onAddChildClick(task);
+                  }}
+                >
+                  + 하위
+                </Button>
+              )}
+              {onDeleteClick && (
+                <Button
+                  size="xs"
+                  variant="ghost"
+                  colorPalette="red"
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    onDeleteClick(task);
+                  }}
+                >
+                  삭제
+                </Button>
+              )}
+            </Flex>
+          </Box>
+        );
+      })}
     </Stack>
   );
 }

--- a/components/task-list.tsx
+++ b/components/task-list.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useMemo } from 'react';
+import { useMemo, useState } from 'react';
 import { Box, Button, Flex, Stack, Text } from '@chakra-ui/react';
 import type { Task } from '@/lib/db/schema';
 import { buildTaskTree, type TaskNode } from '@/lib/tasks/build-tree';
@@ -12,20 +12,33 @@ export type TaskListProps = {
   onDeleteClick?: (task: Task) => void;
 };
 
-function flattenTree(nodes: TaskNode[]): TaskNode[] {
+function flattenVisibleNodes(nodes: TaskNode[], collapsedIds: Set<string>): TaskNode[] {
   const out: TaskNode[] = [];
   const walk = (n: TaskNode): void => {
     out.push(n);
-    for (const child of n.children) walk(child);
+    if (!collapsedIds.has(n.task.id)) {
+      for (const child of n.children) walk(child);
+    }
   };
   for (const n of nodes) walk(n);
   return out;
 }
 
 export function TaskList({ tasks, onRowClick, onAddChildClick, onDeleteClick }: TaskListProps) {
-  const flatNodes = useMemo(() => flattenTree(buildTaskTree(tasks)), [tasks]);
+  const tree = useMemo(() => buildTaskTree(tasks), [tasks]);
+  const [collapsedIds, setCollapsedIds] = useState<Set<string>>(() => new Set());
+  const visibleNodes = useMemo(() => flattenVisibleNodes(tree, collapsedIds), [tree, collapsedIds]);
 
-  if (flatNodes.length === 0) {
+  const toggleCollapsed = (id: string): void => {
+    setCollapsedIds((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
+      return next;
+    });
+  };
+
+  if (tree.length === 0) {
     return (
       <Box py={10} textAlign="center">
         <Text color="fg.muted">아직 작업이 없습니다. 첫 작업을 추가해 시작하세요</Text>
@@ -35,9 +48,10 @@ export function TaskList({ tasks, onRowClick, onAddChildClick, onDeleteClick }: 
 
   return (
     <Stack gap={2}>
-      {flatNodes.map((node) => {
+      {visibleNodes.map((node) => {
         const { task, depth, children } = node;
         const hasChildren = children.length > 0;
+        const isCollapsed = collapsedIds.has(task.id);
         return (
           <Box
             key={task.id}
@@ -60,7 +74,21 @@ export function TaskList({ tasks, onRowClick, onAddChildClick, onDeleteClick }: 
             _hover={{ bg: 'bg.subtle' }}
           >
             <Flex gap={4} align="center">
-              <Box minW={4}>{hasChildren && <Text as="span">▼</Text>}</Box>
+              <Box minW={4}>
+                {hasChildren && (
+                  <Button
+                    size="xs"
+                    variant="ghost"
+                    aria-label={isCollapsed ? '펼치기' : '접기'}
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      toggleCollapsed(task.id);
+                    }}
+                  >
+                    {isCollapsed ? '▶' : '▼'}
+                  </Button>
+                )}
+              </Box>
               <Text flex="1" fontWeight="medium">{task.title}</Text>
               <Text color="fg.muted" minW="20">{task.assignee ?? '—'}</Text>
               <Text fontSize="sm">{task.status}</Text>

--- a/lib/tasks/__tests__/build-tree.test.ts
+++ b/lib/tasks/__tests__/build-tree.test.ts
@@ -1,0 +1,86 @@
+/**
+ * RED: buildTaskTree (Issue #4 Stage 1).
+ * 근거: SPEC.md §5 E-1/E-2/E-3, §1 A-3 (형제 createdAt ASC).
+ */
+import { describe, it, expect } from 'vitest';
+import { buildTaskTree } from '@/lib/tasks/build-tree';
+import type { Task } from '@/lib/db/schema';
+
+function makeTask(overrides: Partial<Task> & { id: string }): Task {
+  return {
+    id: overrides.id,
+    parentId: overrides.parentId ?? null,
+    title: overrides.title ?? `t-${overrides.id}`,
+    description: null,
+    assignee: null,
+    status: 'todo',
+    progress: 0,
+    startDate: null,
+    dueDate: null,
+    createdAt: overrides.createdAt ?? new Date('2026-04-01T00:00:00Z'),
+    updatedAt: overrides.updatedAt ?? new Date('2026-04-01T00:00:00Z'),
+  };
+}
+
+describe('buildTaskTree', () => {
+  it('빈 배열 → 빈 트리', () => {
+    expect(buildTaskTree([])).toEqual([]);
+  });
+
+  it('모두 최상위(parentId=null) → roots 만, depth=0', () => {
+    const t1 = makeTask({ id: 'a' });
+    const t2 = makeTask({ id: 'b' });
+    const tree = buildTaskTree([t1, t2]);
+    expect(tree).toHaveLength(2);
+    expect(tree.every((n) => n.depth === 0)).toBe(true);
+    expect(tree.every((n) => n.children.length === 0)).toBe(true);
+  });
+
+  it('부모 → 자식 → children 에 포함, depth=1', () => {
+    const parent = makeTask({ id: 'p' });
+    const child = makeTask({ id: 'c', parentId: 'p' });
+    const tree = buildTaskTree([parent, child]);
+    expect(tree).toHaveLength(1);
+    expect(tree[0].task.id).toBe('p');
+    expect(tree[0].depth).toBe(0);
+    expect(tree[0].children).toHaveLength(1);
+    expect(tree[0].children[0].task.id).toBe('c');
+    expect(tree[0].children[0].depth).toBe(1);
+  });
+
+  it('손자까지 3단계 재귀 중첩, depth=2', () => {
+    const p = makeTask({ id: 'p' });
+    const c = makeTask({ id: 'c', parentId: 'p' });
+    const g = makeTask({ id: 'g', parentId: 'c' });
+    const tree = buildTaskTree([p, c, g]);
+    const grandchild = tree[0].children[0].children[0];
+    expect(grandchild.task.id).toBe('g');
+    expect(grandchild.depth).toBe(2);
+  });
+
+  it('형제 순서는 createdAt ASC 유지 (SPEC A-3)', () => {
+    const later = makeTask({ id: 'later', createdAt: new Date('2026-05-02T00:00:00Z') });
+    const first = makeTask({ id: 'first', createdAt: new Date('2026-05-01T00:00:00Z') });
+    const middle = makeTask({ id: 'middle', createdAt: new Date('2026-05-01T12:00:00Z') });
+    const tree = buildTaskTree([later, first, middle]);
+    expect(tree.map((n) => n.task.id)).toEqual(['first', 'middle', 'later']);
+  });
+
+  it('orphan parentId(존재하지 않는 부모 UUID) → root 로 승격 (방어)', () => {
+    const orphan = makeTask({ id: 'orphan', parentId: '00000000-0000-0000-0000-000000000000' });
+    const tree = buildTaskTree([orphan]);
+    expect(tree).toHaveLength(1);
+    expect(tree[0].task.id).toBe('orphan');
+    expect(tree[0].depth).toBe(0);
+  });
+
+  it('입력 순서가 뒤섞여도 정상 트리 (자식 먼저, 부모 나중)', () => {
+    const parent = makeTask({ id: 'p', createdAt: new Date('2026-05-01T00:00:00Z') });
+    const child = makeTask({ id: 'c', parentId: 'p', createdAt: new Date('2026-05-02T00:00:00Z') });
+    const tree = buildTaskTree([child, parent]);
+    expect(tree).toHaveLength(1);
+    expect(tree[0].task.id).toBe('p');
+    expect(tree[0].children[0].task.id).toBe('c');
+    expect(tree[0].children[0].depth).toBe(1);
+  });
+});

--- a/lib/tasks/build-tree.ts
+++ b/lib/tasks/build-tree.ts
@@ -1,0 +1,12 @@
+import type { Task } from '@/lib/db/schema';
+
+export type TaskNode = {
+  task: Task;
+  children: TaskNode[];
+  depth: number;
+};
+
+export function buildTaskTree(_tasks: Task[]): TaskNode[] {
+  // RED 스텁 — GREEN 단계에서 실제 트리 빌드로 교체.
+  throw new Error('not implemented');
+}

--- a/lib/tasks/build-tree.ts
+++ b/lib/tasks/build-tree.ts
@@ -6,7 +6,36 @@ export type TaskNode = {
   depth: number;
 };
 
-export function buildTaskTree(_tasks: Task[]): TaskNode[] {
-  // RED 스텁 — GREEN 단계에서 실제 트리 빌드로 교체.
-  throw new Error('not implemented');
+export function buildTaskTree(tasks: Task[]): TaskNode[] {
+  // 1) createdAt ASC 로 정렬해 형제 순서를 SPEC A-3 로 정규화.
+  const sorted = [...tasks].sort(
+    (a, b) => a.createdAt.getTime() - b.createdAt.getTime(),
+  );
+
+  // 2) id → 노드 맵.
+  const nodeMap = new Map<string, TaskNode>();
+  for (const task of sorted) {
+    nodeMap.set(task.id, { task, children: [], depth: 0 });
+  }
+
+  // 3) 각 노드를 부모의 children 에 붙이거나, orphan / null 이면 root 로.
+  const roots: TaskNode[] = [];
+  for (const task of sorted) {
+    const node = nodeMap.get(task.id)!;
+    const parent = task.parentId ? nodeMap.get(task.parentId) : undefined;
+    if (parent && parent !== node) {
+      parent.children.push(node);
+    } else {
+      roots.push(node);
+    }
+  }
+
+  // 4) root 부터 재귀로 depth 주입.
+  const setDepth = (node: TaskNode, depth: number): void => {
+    node.depth = depth;
+    for (const child of node.children) setDepth(child, depth + 1);
+  };
+  for (const root of roots) setDepth(root, 0);
+
+  return roots;
 }


### PR DESCRIPTION
## Summary
- SPEC.md §5 E (계층) · §1 A-4 (목업) 을 TDD 3단계로 구현. Stage 4 는 API 불변 검증 스모크.
- 6커밋 (Stage 1/2/3 각 RED+GREEN 쌍) · 유닛 49 passed · 통합 30 passed · Playwright 스모크 통과.
- TaskList 외부 API 불변 → `app/page.tsx` · `TasksPageClient` **수정 없음**.

## TDD 사이클

| 단계 | RED | GREEN |
|---|---|---|
| 1. `buildTaskTree` 순수 함수 | `e25f2f6` (7 fail) | `cd79f16` (7 pass) |
| 2. TaskList 트리 렌더 (전체 펼침 기본) | `2ef84ed` (4 fail) | `60465e5` (5 pass) |
| 3. 펼침/접힘 상호작용 | `e8b5580` (4 fail) | `73ef221` (4 pass) |
| 4. 페이지 통합 + Playwright | 코드 변경 없음 | MCP 수동 검증 ✓ |

## 구현 하이라이트
- **트리 빌드**: 4-pass (createdAt 정렬 → id 맵 → 부모 children 삽입 or root 승격 → 재귀 depth) — `self-parent` · `orphan parentId` 방어
- **렌더**: `useMemo(buildTaskTree + flattenVisibleNodes(collapsedIds))` → DFS 순서 + 접힌 서브트리 스킵
- **토글**: `aria-label="접기"/"펼치기"` Chakra Button, `e.stopPropagation()` 으로 행 클릭과 분리
- **접힘 상태**: `Set<string>` useState, immutable 갱신 (localStorage 퍼시스턴스 없음 — MVP)
- **들여쓰기**: `pl={3 + depth * 6}` + `data-depth` 속성 (테스트·디버깅)

## Test plan
- [x] `npm test` — 49 passed (유닛)
- [x] `npm run test:integration` — 30 passed (회귀 없음)
- [x] `npx tsc --noEmit` / `npm run lint` / `npm run build` 모두 깨끗
- [x] **Playwright MCP 스모크**:
  - 3단계 계층 생성: 킥오프 미팅 → 아젠다 초안 → 브리프 작성
  - 스크린샷으로 들여쓰기 시각 확인
  - 최상위 "접기" 클릭 → 자식·손자 모두 숨김, 아이콘 ▶
  - "펼치기" 클릭 → 손자까지 복원, 아이콘 ▼
  - 토글 / "+ 하위" / "삭제" 버튼이 각각 독립 동작

## 범위 밖 (후속 이슈)
- #5 인라인 상태 배지 클릭 · 진행률 100 → 완료 자동
- #6 CSV 계층 직렬화/역직렬화
- #7 간트 뷰
- #11 Overdue 표시
- 접힘 상태 퍼시스턴스 · 자식 수 배지 · 키보드 네비게이션 (polish)

Closes #4

🤖 Generated with [Claude Code](https://claude.com/claude-code)