### PR TITLE
feat: #5 인라인 상태 배지 + progress→status 자동 규칙 (TDD 5단계)

### DIFF
--- a/app/actions/tasks.ts
+++ b/app/actions/tasks.ts
@@ -4,7 +4,12 @@ import { eq, sql as drizzleSql } from 'drizzle-orm';
 import { revalidatePath } from 'next/cache';
 import { db } from '@/lib/db';
 import { tasks } from '@/lib/db/schema';
-import { validateTaskInput, TaskValidationError, type TaskInput } from '@/lib/validation/task';
+import {
+  validateTaskInput,
+  applyProgressCompletionRule,
+  TaskValidationError,
+  type TaskInput,
+} from '@/lib/validation/task';
 
 function throwIfInvalid(input: TaskInput): void {
   const result = validateTaskInput(input);
@@ -12,19 +17,20 @@ function throwIfInvalid(input: TaskInput): void {
 }
 
 export async function createTask(input: TaskInput) {
-  throwIfInvalid(input);
+  const processed = applyProgressCompletionRule(input);
+  throwIfInvalid(processed);
 
   const [row] = await db
     .insert(tasks)
     .values({
-      title: (input.title ?? '').trim(),
-      description: input.description ?? null,
-      assignee: input.assignee ?? null,
-      status: input.status ?? 'todo',
-      progress: input.progress ?? 0,
-      startDate: input.startDate ?? null,
-      dueDate: input.dueDate ?? null,
-      parentId: input.parentId ?? null,
+      title: (processed.title ?? '').trim(),
+      description: processed.description ?? null,
+      assignee: processed.assignee ?? null,
+      status: processed.status ?? 'todo',
+      progress: processed.progress ?? 0,
+      startDate: processed.startDate ?? null,
+      dueDate: processed.dueDate ?? null,
+      parentId: processed.parentId ?? null,
     })
     .returning();
 
@@ -38,27 +44,30 @@ export async function updateTask(id: string, patch: TaskInput) {
     throw new Error(`Task ${id} 를 찾을 수 없습니다`);
   }
 
-  // merge existing + patch 로 검증 — 부분 patch 에서도 전체 불변식을 유지.
+  // SPEC §3 C-2 규칙: progress=100 이면 status='done' 자동 승격 (역방향 없음).
+  const processed = applyProgressCompletionRule(patch);
+
+  // merge existing + processed 로 검증 — 부분 patch 에서도 전체 불변식을 유지.
   throwIfInvalid({
-    title: patch.title ?? existing.title,
-    description: 'description' in patch ? patch.description : existing.description,
-    assignee: 'assignee' in patch ? patch.assignee : existing.assignee,
-    status: patch.status ?? existing.status,
-    progress: patch.progress ?? existing.progress,
-    startDate: 'startDate' in patch ? patch.startDate : existing.startDate,
-    dueDate: 'dueDate' in patch ? patch.dueDate : existing.dueDate,
-    parentId: 'parentId' in patch ? patch.parentId : existing.parentId,
+    title: processed.title ?? existing.title,
+    description: 'description' in processed ? processed.description : existing.description,
+    assignee: 'assignee' in processed ? processed.assignee : existing.assignee,
+    status: processed.status ?? existing.status,
+    progress: processed.progress ?? existing.progress,
+    startDate: 'startDate' in processed ? processed.startDate : existing.startDate,
+    dueDate: 'dueDate' in processed ? processed.dueDate : existing.dueDate,
+    parentId: 'parentId' in processed ? processed.parentId : existing.parentId,
   });
 
   const updates: Record<string, unknown> = { updatedAt: new Date() };
-  if (patch.title !== undefined) updates.title = patch.title.trim();
-  if ('description' in patch) updates.description = patch.description;
-  if ('assignee' in patch) updates.assignee = patch.assignee;
-  if (patch.status !== undefined) updates.status = patch.status;
-  if (patch.progress !== undefined) updates.progress = patch.progress;
-  if ('startDate' in patch) updates.startDate = patch.startDate;
-  if ('dueDate' in patch) updates.dueDate = patch.dueDate;
-  if ('parentId' in patch) updates.parentId = patch.parentId;
+  if (processed.title !== undefined) updates.title = processed.title.trim();
+  if ('description' in processed) updates.description = processed.description;
+  if ('assignee' in processed) updates.assignee = processed.assignee;
+  if (processed.status !== undefined) updates.status = processed.status;
+  if (processed.progress !== undefined) updates.progress = processed.progress;
+  if ('startDate' in processed) updates.startDate = processed.startDate;
+  if ('dueDate' in processed) updates.dueDate = processed.dueDate;
+  if ('parentId' in processed) updates.parentId = processed.parentId;
 
   const [row] = await db.update(tasks).set(updates).where(eq(tasks.id, id)).returning();
   revalidatePath('/');

--- a/components/__tests__/status-badge.test.tsx
+++ b/components/__tests__/status-badge.test.tsx
@@ -1,0 +1,44 @@
+/**
+ * RED: StatusBadge (Issue #5 Stage 3, SPEC §3 C-2).
+ */
+import { describe, it, expect, vi } from 'vitest';
+import { screen, fireEvent } from '@testing-library/react';
+import { StatusBadge } from '../status-badge';
+import { renderWithChakra } from './helpers';
+import type { TaskStatus } from '@/lib/validation/task';
+
+describe('<StatusBadge />', () => {
+  it.each<[TaskStatus, string]>([
+    ['todo', '할 일'],
+    ['doing', '진행 중'],
+    ['done', '완료'],
+  ])('status=%s → 한글 라벨 "%s" 표시', (status, label) => {
+    renderWithChakra(<StatusBadge status={status} />);
+    expect(screen.getByText(label)).toBeInTheDocument();
+  });
+
+  it('onCycle 없으면 button 렌더 안 됨 (읽기 전용)', () => {
+    renderWithChakra(<StatusBadge status="todo" />);
+    expect(screen.queryByRole('button')).toBeNull();
+  });
+
+  it('onCycle 제공 시 button 렌더, 클릭 → onCycle 호출', () => {
+    const onCycle = vi.fn();
+    renderWithChakra(<StatusBadge status="todo" onCycle={onCycle} />);
+    fireEvent.click(screen.getByRole('button'));
+    expect(onCycle).toHaveBeenCalledTimes(1);
+  });
+
+  it('배지 클릭은 부모 onClick 을 호출하지 않음 (stopPropagation)', () => {
+    const parentClick = vi.fn();
+    const onCycle = vi.fn();
+    renderWithChakra(
+      <div onClick={parentClick} role="presentation">
+        <StatusBadge status="todo" onCycle={onCycle} />
+      </div>,
+    );
+    fireEvent.click(screen.getByRole('button'));
+    expect(onCycle).toHaveBeenCalled();
+    expect(parentClick).not.toHaveBeenCalled();
+  });
+});

--- a/components/__tests__/task-form-modal.test.tsx
+++ b/components/__tests__/task-form-modal.test.tsx
@@ -66,4 +66,35 @@ describe('<TaskFormModal />', () => {
     expect(screen.getByText(/목표 기한은 시작일/)).toBeInTheDocument();
     expect(screen.getByRole('button', { name: /저장/ })).toBeDisabled();
   });
+
+  describe('진행률 ↔ 상태 자동 반영 (Stage 4, SPEC §3 C-2)', () => {
+    it('진행률 100 입력 → 상태 select 값이 "done" 으로 자동 전환', () => {
+      renderWithChakra(
+        <TaskFormModal mode="create" open onSubmit={vi.fn()} onClose={vi.fn()} />,
+      );
+      fireEvent.change(screen.getByLabelText(/제목/), { target: { value: 'X' } });
+      fireEvent.change(screen.getByLabelText(/진행률/), { target: { value: '100' } });
+      expect((screen.getByLabelText(/상태/) as HTMLSelectElement).value).toBe('done');
+    });
+
+    it('진행률 100 후 상태를 "진행 중" 으로 수동 변경 → 진행률 100 유지 (역방향 없음)', () => {
+      renderWithChakra(
+        <TaskFormModal mode="create" open onSubmit={vi.fn()} onClose={vi.fn()} />,
+      );
+      fireEvent.change(screen.getByLabelText(/제목/), { target: { value: 'X' } });
+      fireEvent.change(screen.getByLabelText(/진행률/), { target: { value: '100' } });
+      fireEvent.change(screen.getByLabelText(/상태/), { target: { value: 'doing' } });
+      expect((screen.getByLabelText(/진행률/) as HTMLInputElement).value).toBe('100');
+      expect((screen.getByLabelText(/상태/) as HTMLSelectElement).value).toBe('doing');
+    });
+
+    it('진행률 99 입력 → 상태 변경 없음 (초기 todo 유지)', () => {
+      renderWithChakra(
+        <TaskFormModal mode="create" open onSubmit={vi.fn()} onClose={vi.fn()} />,
+      );
+      fireEvent.change(screen.getByLabelText(/제목/), { target: { value: 'X' } });
+      fireEvent.change(screen.getByLabelText(/진행률/), { target: { value: '99' } });
+      expect((screen.getByLabelText(/상태/) as HTMLSelectElement).value).toBe('todo');
+    });
+  });
 });

--- a/components/__tests__/task-list.test.tsx
+++ b/components/__tests__/task-list.test.tsx
@@ -114,6 +114,44 @@ describe('<TaskList />', () => {
     });
   });
 
+  describe('상태 배지 배선 (Issue #5 Stage 5, SPEC §3 C-2)', () => {
+    it('onStatusCycle 없으면 배지는 한글 라벨만 읽기 전용 표시', () => {
+      const t = makeTask({ id: 'x', title: 'X', status: 'todo' });
+      renderWithChakra(<TaskList tasks={[t]} onRowClick={vi.fn()} />);
+      expect(screen.getByText('할 일')).toBeInTheDocument();
+    });
+
+    it('onStatusCycle 제공 시 배지 버튼 클릭 → 해당 task 로 콜백 호출', () => {
+      const t = makeTask({ id: 'x', title: 'X', status: 'doing' });
+      const onStatusCycle = vi.fn();
+      renderWithChakra(
+        <TaskList
+          tasks={[t]}
+          onRowClick={vi.fn()}
+          onStatusCycle={onStatusCycle}
+        />,
+      );
+      fireEvent.click(screen.getByRole('button', { name: /진행 중/ }));
+      expect(onStatusCycle).toHaveBeenCalledWith(t);
+    });
+
+    it('배지 클릭은 onRowClick 호출 안 됨 (stopPropagation)', () => {
+      const t = makeTask({ id: 'x', title: 'X', status: 'todo' });
+      const onStatusCycle = vi.fn();
+      const onRowClick = vi.fn();
+      renderWithChakra(
+        <TaskList
+          tasks={[t]}
+          onRowClick={onRowClick}
+          onStatusCycle={onStatusCycle}
+        />,
+      );
+      fireEvent.click(screen.getByRole('button', { name: /할 일/ }));
+      expect(onStatusCycle).toHaveBeenCalled();
+      expect(onRowClick).not.toHaveBeenCalled();
+    });
+  });
+
   describe('펼침/접힘 (Stage 3, SPEC §5 E-2)', () => {
     it('접기 버튼 클릭 → ▶ 로 바뀌고 자식 숨김', () => {
       const p = makeTask({ id: 'p', title: 'Parent' });

--- a/components/status-badge.tsx
+++ b/components/status-badge.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { Badge, Button } from '@chakra-ui/react';
 import type { TaskStatus } from '@/lib/validation/task';
 
 export type StatusBadgeProps = {
@@ -7,7 +8,42 @@ export type StatusBadgeProps = {
   onCycle?: () => void;
 };
 
-export function StatusBadge(_props: StatusBadgeProps) {
-  // RED 스텁 — GREEN 단계에서 실제 배지로 교체.
-  return null;
+const LABEL: Record<TaskStatus, string> = {
+  todo: '할 일',
+  doing: '진행 중',
+  done: '완료',
+};
+
+const COLOR: Record<TaskStatus, string> = {
+  todo: 'gray',
+  doing: 'blue',
+  done: 'green',
+};
+
+export function StatusBadge({ status, onCycle }: StatusBadgeProps) {
+  const label = LABEL[status];
+  const color = COLOR[status];
+
+  if (onCycle) {
+    return (
+      <Button
+        size="xs"
+        variant="subtle"
+        colorPalette={color}
+        aria-label={`상태: ${label}, 클릭하여 다음 상태로`}
+        onClick={(e) => {
+          e.stopPropagation();
+          onCycle();
+        }}
+      >
+        {label}
+      </Button>
+    );
+  }
+
+  return (
+    <Badge colorPalette={color} variant="subtle">
+      {label}
+    </Badge>
+  );
 }

--- a/components/status-badge.tsx
+++ b/components/status-badge.tsx
@@ -1,0 +1,13 @@
+'use client';
+
+import type { TaskStatus } from '@/lib/validation/task';
+
+export type StatusBadgeProps = {
+  status: TaskStatus;
+  onCycle?: () => void;
+};
+
+export function StatusBadge(_props: StatusBadgeProps) {
+  // RED 스텁 — GREEN 단계에서 실제 배지로 교체.
+  return null;
+}

--- a/components/task-form-modal.tsx
+++ b/components/task-form-modal.tsx
@@ -3,7 +3,7 @@
 import { useMemo, useState } from 'react';
 import { Box, Button, Heading, Input, Stack, Text, Textarea } from '@chakra-ui/react';
 import type { TaskInput } from '@/lib/validation/task';
-import { validateTaskInput } from '@/lib/validation/task';
+import { validateTaskInput, applyProgressCompletionRule } from '@/lib/validation/task';
 import type { Task } from '@/lib/db/schema';
 
 export type TaskFormModalProps = {
@@ -114,7 +114,20 @@ export function TaskFormModal({ mode, open, initialValue, onSubmit, onClose }: T
             min={0}
             max={100}
             value={values.progress}
-            onChange={(e) => setValues({ ...values, progress: Number(e.target.value) })}
+            onChange={(e) => {
+              const nextProgress = Number(e.target.value);
+              // SPEC §3 C-2: progress === 100 → status='done' 자동 승격.
+              // 규칙을 순수 함수로 재사용해 UI / 서버에서 동일 동작.
+              const processed = applyProgressCompletionRule({
+                progress: nextProgress,
+                status: values.status,
+              });
+              setValues({
+                ...values,
+                progress: nextProgress,
+                status: (processed.status as FormValues['status']) ?? values.status,
+              });
+            }}
           />
           {errors.progress && <Text color="red.500" fontSize="sm">{errors.progress}</Text>}
         </Box>

--- a/components/task-list.tsx
+++ b/components/task-list.tsx
@@ -3,13 +3,16 @@
 import { useMemo, useState } from 'react';
 import { Box, Button, Flex, Stack, Text } from '@chakra-ui/react';
 import type { Task } from '@/lib/db/schema';
+import type { TaskStatus } from '@/lib/validation/task';
 import { buildTaskTree, type TaskNode } from '@/lib/tasks/build-tree';
+import { StatusBadge } from './status-badge';
 
 export type TaskListProps = {
   tasks: Task[];
   onRowClick: (task: Task) => void;
   onAddChildClick?: (task: Task) => void;
   onDeleteClick?: (task: Task) => void;
+  onStatusCycle?: (task: Task) => void;
 };
 
 function flattenVisibleNodes(nodes: TaskNode[], collapsedIds: Set<string>): TaskNode[] {
@@ -24,7 +27,7 @@ function flattenVisibleNodes(nodes: TaskNode[], collapsedIds: Set<string>): Task
   return out;
 }
 
-export function TaskList({ tasks, onRowClick, onAddChildClick, onDeleteClick }: TaskListProps) {
+export function TaskList({ tasks, onRowClick, onAddChildClick, onDeleteClick, onStatusCycle }: TaskListProps) {
   const tree = useMemo(() => buildTaskTree(tasks), [tasks]);
   const [collapsedIds, setCollapsedIds] = useState<Set<string>>(() => new Set());
   const visibleNodes = useMemo(() => flattenVisibleNodes(tree, collapsedIds), [tree, collapsedIds]);
@@ -91,7 +94,10 @@ export function TaskList({ tasks, onRowClick, onAddChildClick, onDeleteClick }: 
               </Box>
               <Text flex="1" fontWeight="medium">{task.title}</Text>
               <Text color="fg.muted" minW="20">{task.assignee ?? '—'}</Text>
-              <Text fontSize="sm">{task.status}</Text>
+              <StatusBadge
+                status={task.status as TaskStatus}
+                onCycle={onStatusCycle ? () => onStatusCycle(task) : undefined}
+              />
               <Text fontSize="sm" minW="12" textAlign="right">{task.progress}%</Text>
               {onAddChildClick && (
                 <Button

--- a/components/tasks-page-client.tsx
+++ b/components/tasks-page-client.tsx
@@ -3,7 +3,8 @@
 import { useState, useTransition } from 'react';
 import { Box, Button, Flex, Heading } from '@chakra-ui/react';
 import type { Task } from '@/lib/db/schema';
-import type { TaskInput } from '@/lib/validation/task';
+import type { TaskInput, TaskStatus } from '@/lib/validation/task';
+import { cycleStatus } from '@/lib/validation/task';
 import { createTask, updateTask, deleteTask, getDescendantCount } from '@/app/actions/tasks';
 import { TaskList } from './task-list';
 import { TaskFormModal } from './task-form-modal';
@@ -64,6 +65,17 @@ export function TasksPageClient({ initialTasks }: { initialTasks: Task[] }) {
     setModal({ kind: 'delete', task, childCount });
   };
 
+  const handleStatusCycle = (task: Task) => {
+    const next = cycleStatus(task.status as TaskStatus);
+    startTransition(async () => {
+      try {
+        await updateTask(task.id, { status: next });
+      } catch (err) {
+        console.error('updateTask (status cycle) failed', err);
+      }
+    });
+  };
+
   return (
     <Box p={6} maxW="5xl" mx="auto">
       <Flex justify="space-between" align="center" mb={6}>
@@ -78,6 +90,7 @@ export function TasksPageClient({ initialTasks }: { initialTasks: Task[] }) {
         onRowClick={(task) => setModal({ kind: 'edit', task })}
         onAddChildClick={(task) => setModal({ kind: 'create', parentId: task.id })}
         onDeleteClick={(task) => void openDelete(task)}
+        onStatusCycle={handleStatusCycle}
       />
 
       {modal.kind === 'create' && (

--- a/lib/validation/__tests__/task.test.ts
+++ b/lib/validation/__tests__/task.test.ts
@@ -5,7 +5,11 @@
  * 이 단계에서 구현 (lib/validation/task.ts) 은 'not implemented' throw — 전 테스트 실패가 정상.
  */
 import { describe, it, expect } from 'vitest';
-import { validateTaskInput } from '@/lib/validation/task';
+import {
+  validateTaskInput,
+  cycleStatus,
+  applyProgressCompletionRule,
+} from '@/lib/validation/task';
 
 describe('validateTaskInput', () => {
   describe('title (B-2 필수 필드)', () => {
@@ -117,5 +121,56 @@ describe('validateTaskInput', () => {
         expect(Object.keys(result.errors).sort()).toEqual(['progress', 'status', 'title']);
       }
     });
+  });
+});
+
+describe('cycleStatus (Issue #5 Stage 1, SPEC §3 C-2)', () => {
+  it("'todo' → 'doing'", () => {
+    expect(cycleStatus('todo')).toBe('doing');
+  });
+  it("'doing' → 'done'", () => {
+    expect(cycleStatus('doing')).toBe('done');
+  });
+  it("'done' → 'todo' (순환)", () => {
+    expect(cycleStatus('done')).toBe('todo');
+  });
+});
+
+describe('applyProgressCompletionRule (Issue #5 Stage 1, SPEC §3 C-2)', () => {
+  it('progress=100, status=todo → status=done, 다른 필드 보존', () => {
+    const input = { title: 'X', progress: 100, status: 'todo', assignee: '김PM' };
+    const result = applyProgressCompletionRule(input);
+    expect(result.status).toBe('done');
+    expect(result.progress).toBe(100);
+    expect(result.title).toBe('X');
+    expect(result.assignee).toBe('김PM');
+  });
+
+  it('progress=100, status=doing → status=done', () => {
+    const result = applyProgressCompletionRule({ title: 'X', progress: 100, status: 'doing' });
+    expect(result.status).toBe('done');
+  });
+
+  it('progress=100, status=done → idempotent (그대로)', () => {
+    const result = applyProgressCompletionRule({ title: 'X', progress: 100, status: 'done' });
+    expect(result.status).toBe('done');
+    expect(result.progress).toBe(100);
+  });
+
+  it('progress=99 → status 변경 없음', () => {
+    const result = applyProgressCompletionRule({ title: 'X', progress: 99, status: 'todo' });
+    expect(result.status).toBe('todo');
+  });
+
+  it('progress=undefined → 변경 없음', () => {
+    const result = applyProgressCompletionRule({ title: 'X', status: 'doing' });
+    expect(result.status).toBe('doing');
+    expect(result.progress).toBeUndefined();
+  });
+
+  it('status=done 만 들어와도 progress 건드리지 않음 (역방향 없음)', () => {
+    const result = applyProgressCompletionRule({ title: 'X', status: 'done', progress: 50 });
+    expect(result.status).toBe('done');
+    expect(result.progress).toBe(50);
   });
 });

--- a/lib/validation/task.ts
+++ b/lib/validation/task.ts
@@ -22,12 +22,23 @@ export class TaskValidationError extends Error {
 
 export type TaskStatus = 'todo' | 'doing' | 'done';
 
-export function cycleStatus(_current: TaskStatus): TaskStatus {
-  throw new Error('not implemented');
+const STATUS_CYCLE: Record<TaskStatus, TaskStatus> = {
+  todo: 'doing',
+  doing: 'done',
+  done: 'todo',
+};
+
+export function cycleStatus(current: TaskStatus): TaskStatus {
+  return STATUS_CYCLE[current];
 }
 
-export function applyProgressCompletionRule(_input: TaskInput): TaskInput {
-  throw new Error('not implemented');
+// SPEC §3 C-2: progress === 100 이면 status 를 'done' 으로 자동 승격.
+// 역방향(단수 status 변화 → progress 조정)은 일부러 안 함 — 사용자가 직접 조정.
+export function applyProgressCompletionRule(input: TaskInput): TaskInput {
+  if (input.progress === 100 && input.status !== 'done') {
+    return { ...input, status: 'done' };
+  }
+  return input;
 }
 
 const ALLOWED_STATUS = ['todo', 'doing', 'done'] as const;

--- a/lib/validation/task.ts
+++ b/lib/validation/task.ts
@@ -20,6 +20,16 @@ export class TaskValidationError extends Error {
   }
 }
 
+export type TaskStatus = 'todo' | 'doing' | 'done';
+
+export function cycleStatus(_current: TaskStatus): TaskStatus {
+  throw new Error('not implemented');
+}
+
+export function applyProgressCompletionRule(_input: TaskInput): TaskInput {
+  throw new Error('not implemented');
+}
+
 const ALLOWED_STATUS = ['todo', 'doing', 'done'] as const;
 
 export function validateTaskInput(input: TaskInput): ValidationResult {

--- a/tests/integration/actions/tasks.test.ts
+++ b/tests/integration/actions/tasks.test.ts
@@ -145,3 +145,32 @@ describe('getDescendantCount (SPEC D-2 "모든 하위 작업 N개")', () => {
     expect(await getDescendantCount(parent.id)).toBe(3); // C + G + GG
   });
 });
+
+describe('applyProgressCompletionRule 적용 (Issue #5 Stage 2, SPEC §3 C-2)', () => {
+  it('updateTask(id, { progress: 100 }) → DB row status=done, progress=100', async () => {
+    const created = await createTask({ title: 'X' });
+    const updated = await updateTask(created.id, { progress: 100 });
+    expect(updated.progress).toBe(100);
+    expect(updated.status).toBe('done');
+  });
+
+  it('updateTask(id, { progress: 50 }) → status 건드리지 않음', async () => {
+    const created = await createTask({ title: 'X', status: 'doing' });
+    const updated = await updateTask(created.id, { progress: 50 });
+    expect(updated.progress).toBe(50);
+    expect(updated.status).toBe('doing');
+  });
+
+  it("updateTask(id, { status: 'done' }) → progress 건드리지 않음 (역방향 없음)", async () => {
+    const created = await createTask({ title: 'X', progress: 50, status: 'doing' });
+    const updated = await updateTask(created.id, { status: 'done' });
+    expect(updated.status).toBe('done');
+    expect(updated.progress).toBe(50);
+  });
+
+  it("createTask({ title: 'X', progress: 100 }) → status='done' 자동", async () => {
+    const created = await createTask({ title: 'X', progress: 100 });
+    expect(created.progress).toBe(100);
+    expect(created.status).toBe('done');
+  });
+});


### PR DESCRIPTION
## Summary
- SPEC.md §3 C-2 의 인라인 편집 편의와 자동 전환 규칙을 TDD 5단계(RED/GREEN) + Playwright 스모크로 구현.
- 10커밋 · 유닛 70 passed · 통합 34 passed · Playwright 검증 통과.
- 규칙은 순수 함수(`cycleStatus`, `applyProgressCompletionRule`)로 UI·서버 양쪽에서 공유.

## TDD 사이클

| 단계 | RED | GREEN |
|---|---|---|
| 1. 순수 함수 | `502e357` (9 fail) | `9ba9e55` (9 pass) |
| 2. Server Action 통합 | `2b94e0b` (2 fail + 2 가드) | `ef286cd` (4 pass) |
| 3. `StatusBadge` 컴포넌트 | `c201734` (5 fail + 1 가드) | `c4ddf89` (6 pass) |
| 4. `TaskFormModal` 자동 반영 | `563a859` (1 fail + 2 가드) | `85ce29f` (3 pass) |
| 5. `TaskList` · `TasksPageClient` 배선 | `5bc713d` (3 fail) | `10452ff` (3 pass) |
| 6. Playwright 스모크 | 코드 변경 없음 | MCP 수동 검증 ✓ |

## 구현 하이라이트
- **`cycleStatus`**: `Record<TaskStatus, TaskStatus>` 룩업 → todo → doing → done → todo
- **`applyProgressCompletionRule`**: progress=100 이고 status 가 done 이 아닐 때만 status='done' 승격 (idempotent, 역방향 없음)
- **서버 방어 적용**: `createTask` 는 validation 전에, `updateTask` 는 merge 전에 규칙 적용 → DB invariant 유지
- **`StatusBadge`**: `onCycle?` 옵셔널 — 있으면 Chakra Button(stopPropagation 내장), 없으면 Chakra Badge
- **`TaskFormModal`**: progress onChange 에서 규칙 호출 → state.status 자동 갱신 (역방향 없음: status 변경은 progress 건드리지 않음)
- **`TasksPageClient.handleStatusCycle`**: `updateTask(task.id, { status: cycleStatus(task.status) })` 부분 patch — progress 불변 보장

## Test plan
- [x] `npm test` — 70 passed (유닛)
- [x] `npm run test:integration` — 34 passed (회귀 없음)
- [x] `npx tsc --noEmit` / `npm run lint` — 깨끗
- [x] **Playwright MCP 스모크**:
  - "리서치" 작업 생성
  - 상태 배지 클릭 3회 → 할 일 → 진행 중 → 완료 → 할 일 (순환 확인, progress 0% 유지)
  - 행 클릭 편집 → 진행률 100 입력 → 상태 select 즉시 "완료" 로 자동
  - 상태 수동 "진행 중" 변경 → UI progress 100 유지 (UI 역방향 없음)
  - 저장 → 서버 방어 규칙이 status='done' 재적용 (forward invariant) · 목록 '완료 / 100%' 표시

## 엣지케이스 (문서화)
저장 시 `progress=100, status='doing'` 상태는 서버 `applyProgressCompletionRule` 이 'done' 으로 재강제. SPEC '역방향 없음' 은 '상태 변경이 진행률을 건드리지 않음' 의 의미이고, forward 규칙은 invariant 로 유지한다는 해석. 인라인 배지 클릭(patch 에 progress 없음)은 영향 없음 — done 배지를 todo 로 내려도 progress 는 그대로.

## 범위 밖 (후속 이슈)
- #6 CSV 가져오기·내보내기
- #7 간트 뷰
- #11 Overdue 시각 표시
- 담당자·날짜·진행률 인라인 편집 (modal 전담 유지)

Closes #5

🤖 Generated with [Claude Code](https://claude.com/claude-code)