### PR TITLE
feat: #6 CSV Import/Export (TDD 6 stages)

### DIFF
--- a/app/actions/csv.ts
+++ b/app/actions/csv.ts
@@ -1,0 +1,66 @@
+'use server';
+
+import { revalidatePath } from 'next/cache';
+import { db } from '@/lib/db';
+import { tasks } from '@/lib/db/schema';
+import { previewCsvImport } from '@/lib/csv/parse';
+
+export type ImportResult = {
+  addedCount: number;
+  skippedCount: number;
+  skipReasons: string[];
+};
+
+export async function applyCsvImport(text: string): Promise<ImportResult> {
+  // 기존 task 전체를 한 번 읽어와 parent title 매칭용으로 사용.
+  const existing = await db.select().from(tasks);
+  const preview = previewCsvImport(text, existing);
+
+  const skipReasons: string[] = preview.skipped.map(
+    (s) => `행 ${s.rowIndex}: ${s.reason}`,
+  );
+  let addedCount = 0;
+  // toAdd 의 각 index → 삽입된 row id 매핑 (실패한 행은 없음).
+  const insertedIdByIndex = new Map<number, string>();
+
+  for (let i = 0; i < preview.toAdd.length; i++) {
+    const row = preview.toAdd[i];
+
+    let parentId: string | null = null;
+    if (row.parent?.kind === 'existing') {
+      parentId = row.parent.id;
+    } else if (row.parent?.kind === 'csvRow') {
+      parentId = insertedIdByIndex.get(row.parent.toAddIndex) ?? null;
+    }
+
+    try {
+      const [inserted] = await db
+        .insert(tasks)
+        .values({
+          title: row.title,
+          description: row.description,
+          assignee: row.assignee,
+          status: row.status,
+          progress: row.progress,
+          startDate: row.startDate,
+          dueDate: row.dueDate,
+          parentId,
+        })
+        .returning();
+      insertedIdByIndex.set(i, inserted.id);
+      addedCount++;
+    } catch (err) {
+      skipReasons.push(
+        `행 (${row.title}): ${err instanceof Error ? err.message : String(err)}`,
+      );
+    }
+  }
+
+  revalidatePath('/');
+
+  return {
+    addedCount,
+    skippedCount: preview.toAdd.length + preview.skipped.length - addedCount,
+    skipReasons,
+  };
+}

--- a/app/api/csv/export/route.ts
+++ b/app/api/csv/export/route.ts
@@ -1,0 +1,4 @@
+export async function GET(): Promise<Response> {
+  // RED 스텁 — GREEN 단계에서 DB select + tasksToCsv + headers 로 교체.
+  throw new Error('not implemented');
+}

--- a/app/api/csv/export/route.ts
+++ b/app/api/csv/export/route.ts
@@ -1,4 +1,22 @@
+import { asc } from 'drizzle-orm';
+import { db } from '@/lib/db';
+import { tasks } from '@/lib/db/schema';
+import { tasksToCsv } from '@/lib/csv/serialize';
+
+export const dynamic = 'force-dynamic';
+
 export async function GET(): Promise<Response> {
-  // RED 스텁 — GREEN 단계에서 DB select + tasksToCsv + headers 로 교체.
-  throw new Error('not implemented');
+  const allTasks = await db.select().from(tasks).orderBy(asc(tasks.createdAt));
+  const csv = tasksToCsv(allTasks);
+
+  const today = new Date().toISOString().slice(0, 10); // YYYY-MM-DD
+
+  return new Response(csv, {
+    status: 200,
+    headers: {
+      'Content-Type': 'text/csv; charset=utf-8',
+      'Content-Disposition': `attachment; filename="wbs-${today}.csv"`,
+      'Cache-Control': 'no-store',
+    },
+  });
 }

--- a/components/__tests__/csv-toolbar.test.tsx
+++ b/components/__tests__/csv-toolbar.test.tsx
@@ -1,0 +1,67 @@
+/**
+ * RED: CsvToolbar (Issue #6 Stage 5, SPEC §6 F-1 · F-2).
+ */
+import { describe, it, expect, vi } from 'vitest';
+import { screen, fireEvent, waitFor } from '@testing-library/react';
+import { CsvToolbar } from '../csv-toolbar';
+import { renderWithChakra } from './helpers';
+
+vi.mock('@/app/actions/csv', () => ({
+  applyCsvImport: vi.fn().mockResolvedValue({
+    addedCount: 1,
+    skippedCount: 0,
+    skipReasons: [],
+  }),
+}));
+
+import { applyCsvImport } from '@/app/actions/csv';
+
+const HEADER = '제목,설명,담당자,상태,진행률,시작일,목표 기한,상위 작업 제목';
+
+describe('<CsvToolbar />', () => {
+  it('"CSV 내보내기" 와 "CSV 불러오기" 버튼 렌더', () => {
+    renderWithChakra(<CsvToolbar existingTasks={[]} />);
+    expect(screen.getByRole('button', { name: /CSV 내보내기/ })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /CSV 불러오기/ })).toBeInTheDocument();
+  });
+
+  it('파일 선택 → 미리보기 다이얼로그에 "N개 추가 · 제외 M건" 표시', async () => {
+    renderWithChakra(<CsvToolbar existingTasks={[]} />);
+    const csv = `${HEADER}\r\nA,,,할 일,0,,,\r\n,,,,0,,,`;
+    const file = new File([csv], 'wbs.csv', { type: 'text/csv' });
+    const input = screen.getByLabelText('CSV 파일 선택') as HTMLInputElement;
+    fireEvent.change(input, { target: { files: [file] } });
+
+    await waitFor(() => {
+      expect(screen.getByText(/1개 추가/)).toBeInTheDocument();
+      expect(screen.getByText(/제외 1건/)).toBeInTheDocument();
+    });
+  });
+
+  it('미리보기에 제외 사유 리스트 노출', async () => {
+    renderWithChakra(<CsvToolbar existingTasks={[]} />);
+    const csv = `${HEADER}\r\n,,,,0,,,`;
+    const file = new File([csv], 'wbs.csv', { type: 'text/csv' });
+    const input = screen.getByLabelText('CSV 파일 선택') as HTMLInputElement;
+    fireEvent.change(input, { target: { files: [file] } });
+
+    await waitFor(() => {
+      expect(screen.getByText(/제목이 비어 있음/)).toBeInTheDocument();
+    });
+  });
+
+  it('"적용" 클릭 → applyCsvImport 호출 (파일 텍스트를 인자로)', async () => {
+    renderWithChakra(<CsvToolbar existingTasks={[]} />);
+    const csv = `${HEADER}\r\nA,,,할 일,0,,,`;
+    const file = new File([csv], 'wbs.csv', { type: 'text/csv' });
+    const input = screen.getByLabelText('CSV 파일 선택') as HTMLInputElement;
+    fireEvent.change(input, { target: { files: [file] } });
+
+    const applyBtn = await screen.findByRole('button', { name: /적용/ });
+    fireEvent.click(applyBtn);
+
+    await waitFor(() => {
+      expect(applyCsvImport).toHaveBeenCalledWith(csv);
+    });
+  });
+});

--- a/components/csv-toolbar.tsx
+++ b/components/csv-toolbar.tsx
@@ -1,0 +1,141 @@
+'use client';
+
+import { useRef, useState, useTransition } from 'react';
+import { Box, Button, Heading, Stack, Text } from '@chakra-ui/react';
+import type { Task } from '@/lib/db/schema';
+import { previewCsvImport, type PreviewResult } from '@/lib/csv/parse';
+import { applyCsvImport, type ImportResult } from '@/app/actions/csv';
+
+export type CsvToolbarProps = {
+  existingTasks: Task[];
+};
+
+type State =
+  | { kind: 'idle' }
+  | { kind: 'preview'; text: string; preview: PreviewResult }
+  | { kind: 'done'; result: ImportResult };
+
+export function CsvToolbar({ existingTasks }: CsvToolbarProps) {
+  const [state, setState] = useState<State>({ kind: 'idle' });
+  const fileInputRef = useRef<HTMLInputElement>(null);
+  const [isPending, startTransition] = useTransition();
+
+  const openFilePicker = () => {
+    fileInputRef.current?.click();
+  };
+
+  const handleFileChange = async (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (!file) return;
+    const text = await file.text();
+    const preview = previewCsvImport(text, existingTasks);
+    setState({ kind: 'preview', text, preview });
+    // 같은 파일을 다시 선택할 수 있도록 input 을 초기화.
+    e.target.value = '';
+  };
+
+  const handleApply = () => {
+    if (state.kind !== 'preview') return;
+    const { text } = state;
+    startTransition(async () => {
+      try {
+        const result = await applyCsvImport(text);
+        setState({ kind: 'done', result });
+      } catch (err) {
+        console.error('applyCsvImport failed', err);
+      }
+    });
+  };
+
+  const close = () => setState({ kind: 'idle' });
+
+  return (
+    <>
+      <Stack direction="row" gap={2}>
+        <Button
+          variant="outline"
+          onClick={() => {
+            window.location.href = '/api/csv/export';
+          }}
+        >
+          CSV 내보내기
+        </Button>
+        <Button variant="outline" onClick={openFilePicker}>
+          CSV 불러오기
+        </Button>
+        <input
+          ref={fileInputRef}
+          type="file"
+          accept=".csv,text/csv"
+          aria-label="CSV 파일 선택"
+          style={{ display: 'none' }}
+          onChange={handleFileChange}
+        />
+      </Stack>
+
+      {state.kind === 'preview' && (
+        <Box
+          mt={4}
+          p={4}
+          borderWidth="1px"
+          borderRadius="md"
+          bg="bg"
+          role="dialog"
+          aria-label="CSV 미리보기"
+        >
+          <Heading size="md" mb={2}>CSV 미리보기</Heading>
+          <Text>
+            {state.preview.toAdd.length}개 추가 · 제외 {state.preview.skipped.length}건
+          </Text>
+          {state.preview.skipped.length > 0 && (
+            <Box mt={3}>
+              <Text fontWeight="medium" fontSize="sm">제외 사유</Text>
+              <Stack gap={1} mt={1}>
+                {state.preview.skipped.map((s, i) => (
+                  <Text key={i} fontSize="sm" color="fg.muted">
+                    행 {s.rowIndex}: {s.reason}
+                  </Text>
+                ))}
+              </Stack>
+            </Box>
+          )}
+          <Stack direction="row" gap={2} mt={4} justify="flex-end">
+            <Button variant="outline" onClick={close}>취소</Button>
+            <Button
+              onClick={handleApply}
+              disabled={isPending || state.preview.toAdd.length === 0}
+            >
+              적용
+            </Button>
+          </Stack>
+        </Box>
+      )}
+
+      {state.kind === 'done' && (
+        <Box
+          mt={4}
+          p={4}
+          borderWidth="1px"
+          borderRadius="md"
+          bg="bg"
+          role="status"
+          aria-label="CSV 가져오기 결과"
+        >
+          <Text>
+            {state.result.addedCount}개 추가됨 · {state.result.skippedCount}건 제외
+          </Text>
+          {state.result.skipReasons.length > 0 && (
+            <Stack gap={1} mt={2}>
+              {state.result.skipReasons.map((r, i) => (
+                <Text key={i} fontSize="sm" color="fg.muted">{r}</Text>
+              ))}
+            </Stack>
+          )}
+          <Stack direction="row" gap={2} mt={4} justify="flex-end">
+            <Button onClick={close}>닫기</Button>
+          </Stack>
+        </Box>
+      )}
+    </>
+  );
+}

--- a/components/tasks-page-client.tsx
+++ b/components/tasks-page-client.tsx
@@ -9,6 +9,7 @@ import { createTask, updateTask, deleteTask, getDescendantCount } from '@/app/ac
 import { TaskList } from './task-list';
 import { TaskFormModal } from './task-form-modal';
 import { DeleteConfirmDialog } from './delete-confirm-dialog';
+import { CsvToolbar } from './csv-toolbar';
 
 type ModalState =
   | { kind: 'none' }
@@ -78,11 +79,14 @@ export function TasksPageClient({ initialTasks }: { initialTasks: Task[] }) {
 
   return (
     <Box p={6} maxW="5xl" mx="auto">
-      <Flex justify="space-between" align="center" mb={6}>
+      <Flex justify="space-between" align="center" mb={6} gap={4}>
         <Heading size="lg">WBS</Heading>
-        <Button onClick={() => setModal({ kind: 'create', parentId: null })}>
-          + 작업 추가
-        </Button>
+        <Flex gap={2} align="center">
+          <CsvToolbar existingTasks={initialTasks} />
+          <Button onClick={() => setModal({ kind: 'create', parentId: null })}>
+            + 작업 추가
+          </Button>
+        </Flex>
       </Flex>
 
       <TaskList

--- a/lib/csv/__tests__/parse.test.ts
+++ b/lib/csv/__tests__/parse.test.ts
@@ -1,0 +1,106 @@
+/**
+ * RED: previewCsvImport (Issue #6 Stage 2, SPEC §6 F-2).
+ */
+import { describe, it, expect } from 'vitest';
+import { previewCsvImport } from '@/lib/csv/parse';
+import type { Task } from '@/lib/db/schema';
+
+const HEADER = '제목,설명,담당자,상태,진행률,시작일,목표 기한,상위 작업 제목';
+
+function makeTask(overrides: Partial<Task> & { id: string; title: string }): Task {
+  return {
+    id: overrides.id,
+    parentId: overrides.parentId ?? null,
+    title: overrides.title,
+    description: overrides.description ?? null,
+    assignee: overrides.assignee ?? null,
+    status: overrides.status ?? 'todo',
+    progress: overrides.progress ?? 0,
+    startDate: overrides.startDate ?? null,
+    dueDate: overrides.dueDate ?? null,
+    createdAt: overrides.createdAt ?? new Date('2026-04-01T00:00:00Z'),
+    updatedAt: overrides.updatedAt ?? new Date('2026-04-01T00:00:00Z'),
+  };
+}
+
+describe('previewCsvImport', () => {
+  it('헤더만 있는 CSV → toAdd=[], skipped=[]', () => {
+    expect(previewCsvImport(HEADER, [])).toEqual({ toAdd: [], skipped: [] });
+  });
+
+  it('정상 행 → 열 순서에 맞게 TaskInput 매핑', () => {
+    const csv = `${HEADER}\r\n킥오프,첫 미팅,김PM,진행 중,30,2026-05-01,2026-05-03,`;
+    const result = previewCsvImport(csv, []);
+    expect(result.skipped).toHaveLength(0);
+    expect(result.toAdd).toHaveLength(1);
+    expect(result.toAdd[0]).toMatchObject({
+      title: '킥오프',
+      description: '첫 미팅',
+      assignee: '김PM',
+      status: 'doing',
+      progress: 30,
+      startDate: '2026-05-01',
+      dueDate: '2026-05-03',
+      parent: null,
+    });
+  });
+
+  it('제목이 비어 있음 → skipped (reason 포함)', () => {
+    const csv = `${HEADER}\r\n,설명만,담당자,할 일,0,,,`;
+    const result = previewCsvImport(csv, []);
+    expect(result.toAdd).toHaveLength(0);
+    expect(result.skipped).toHaveLength(1);
+    expect(result.skipped[0].reason).toMatch(/제목/);
+  });
+
+  it('상태가 허용 외 값 → status=todo fallback, row 는 toAdd 포함', () => {
+    const csv = `${HEADER}\r\nX,,,잘못된상태,0,,,`;
+    const result = previewCsvImport(csv, []);
+    expect(result.skipped).toHaveLength(0);
+    expect(result.toAdd).toHaveLength(1);
+    expect(result.toAdd[0].status).toBe('todo');
+  });
+
+  it('시작일 형식 불량 → startDate=null, row 는 toAdd 포함', () => {
+    const csv = `${HEADER}\r\nX,,,할 일,0,2026/05/01,,`;
+    const result = previewCsvImport(csv, []);
+    expect(result.skipped).toHaveLength(0);
+    expect(result.toAdd).toHaveLength(1);
+    expect(result.toAdd[0].startDate).toBeNull();
+  });
+
+  it('목표 기한 형식 불량 → dueDate=null', () => {
+    const csv = `${HEADER}\r\nX,,,할 일,0,,not-a-date,`;
+    const result = previewCsvImport(csv, []);
+    expect(result.toAdd[0].dueDate).toBeNull();
+  });
+
+  it('상위 작업 제목이 CSV 내 이전 행과 일치 → parent.kind="csvRow"', () => {
+    const csv = `${HEADER}\r\nParent,,,할 일,0,,,\r\nChild,,,할 일,0,,,Parent`;
+    const result = previewCsvImport(csv, []);
+    expect(result.toAdd).toHaveLength(2);
+    expect(result.toAdd[1].parent).toEqual({ kind: 'csvRow', toAddIndex: 0 });
+  });
+
+  it('상위 작업 제목이 기존 DB task 와 일치 → parent.kind="existing"', () => {
+    const csv = `${HEADER}\r\nChild,,,할 일,0,,,ExistingParent`;
+    const existing = [makeTask({ id: 'parent-id', title: 'ExistingParent' })];
+    const result = previewCsvImport(csv, existing);
+    expect(result.toAdd[0].parent).toEqual({ kind: 'existing', id: 'parent-id' });
+  });
+
+  it('상위 작업 제목이 어느 쪽에도 매칭 안 됨 → parent=null', () => {
+    const csv = `${HEADER}\r\nOrphan,,,할 일,0,,,Nonexistent`;
+    const result = previewCsvImport(csv, []);
+    expect(result.toAdd[0].parent).toBeNull();
+  });
+
+  it('RFC 4180: quoted 필드 안의 쉼표·개행·이스케이프 따옴표 파싱', () => {
+    // 제목: 포함, 쉼표 · 설명: 그는 "안녕"\n라고\r\n나머지는 기본값
+    const csv = `${HEADER}\r\n"포함, 쉼표","그는 ""안녕""\n라고",,할 일,0,,,`;
+    const result = previewCsvImport(csv, []);
+    expect(result.toAdd).toHaveLength(1);
+    expect(result.toAdd[0].title).toBe('포함, 쉼표');
+    expect(result.toAdd[0].description).toBe('그는 "안녕"\n라고');
+  });
+});

--- a/lib/csv/__tests__/serialize.test.ts
+++ b/lib/csv/__tests__/serialize.test.ts
@@ -1,0 +1,133 @@
+/**
+ * RED: tasksToCsv (Issue #6 Stage 1, SPEC §6 F-1).
+ * 근거: SPEC §6 F-1 (열 순서, 계층 포함, 동명 부모 "먼저 매칭").
+ */
+import { describe, it, expect } from 'vitest';
+import { tasksToCsv } from '@/lib/csv/serialize';
+import type { Task } from '@/lib/db/schema';
+
+function makeTask(overrides: Partial<Task> & { id: string; title: string }): Task {
+  return {
+    id: overrides.id,
+    parentId: overrides.parentId ?? null,
+    title: overrides.title,
+    description: overrides.description ?? null,
+    assignee: overrides.assignee ?? null,
+    status: overrides.status ?? 'todo',
+    progress: overrides.progress ?? 0,
+    startDate: overrides.startDate ?? null,
+    dueDate: overrides.dueDate ?? null,
+    createdAt: overrides.createdAt ?? new Date('2026-04-01T00:00:00Z'),
+    updatedAt: overrides.updatedAt ?? new Date('2026-04-01T00:00:00Z'),
+  };
+}
+
+const HEADER = '제목,설명,담당자,상태,진행률,시작일,목표 기한,상위 작업 제목';
+
+describe('tasksToCsv', () => {
+  it('빈 배열 → 헤더 행만', () => {
+    expect(tasksToCsv([])).toBe(HEADER);
+  });
+
+  it('단일 task → 헤더 + 1행, 열 순서 정확', () => {
+    const t = makeTask({
+      id: 'a',
+      title: '킥오프',
+      description: '첫 미팅',
+      assignee: '김PM',
+      status: 'doing',
+      progress: 30,
+      startDate: '2026-05-01',
+      dueDate: '2026-05-03',
+    });
+    const csv = tasksToCsv([t]);
+    const lines = csv.split('\r\n');
+    expect(lines[0]).toBe(HEADER);
+    expect(lines[1]).toBe('킥오프,첫 미팅,김PM,진행 중,30,2026-05-01,2026-05-03,');
+  });
+
+  it('상태 값이 한글 라벨로 매핑 (todo / doing / done)', () => {
+    const t1 = makeTask({ id: 'a', title: 't1', status: 'todo' });
+    const t2 = makeTask({
+      id: 'b',
+      title: 't2',
+      status: 'doing',
+      createdAt: new Date('2026-04-02T00:00:00Z'),
+    });
+    const t3 = makeTask({
+      id: 'c',
+      title: 't3',
+      status: 'done',
+      createdAt: new Date('2026-04-03T00:00:00Z'),
+    });
+    const csv = tasksToCsv([t1, t2, t3]);
+    const lines = csv.split('\r\n');
+    expect(lines[1]).toContain('할 일');
+    expect(lines[2]).toContain('진행 중');
+    expect(lines[3]).toContain('완료');
+  });
+
+  it('parentId 없음 → 마지막 "상위 작업 제목" 열이 빈 문자열', () => {
+    const t = makeTask({ id: 'a', title: 'Solo' });
+    const lines = tasksToCsv([t]).split('\r\n');
+    expect(lines[1].endsWith(',')).toBe(true);
+  });
+
+  it('parentId 있음 → 해당 부모의 title 을 마지막 열에 기록', () => {
+    const p = makeTask({ id: 'p', title: 'Parent' });
+    const c = makeTask({
+      id: 'c',
+      title: 'Child',
+      parentId: 'p',
+      createdAt: new Date('2026-04-02T00:00:00Z'),
+    });
+    const lines = tasksToCsv([p, c]).split('\r\n');
+    expect(lines[2].endsWith(',Parent')).toBe(true);
+  });
+
+  it('쉼표·따옴표·개행 포함 필드 → RFC 4180 규칙으로 quote/escape', () => {
+    const t1 = makeTask({ id: 'a', title: '제목, 쉼표 포함' });
+    expect(tasksToCsv([t1])).toContain('"제목, 쉼표 포함"');
+
+    const t2 = makeTask({
+      id: 'b',
+      title: 'X',
+      description: '그는 "안녕" 이라고 말했다',
+    });
+    expect(tasksToCsv([t2])).toContain('"그는 ""안녕"" 이라고 말했다"');
+
+    const t3 = makeTask({ id: 'c', title: 'Y', description: '첫줄\n둘째줄' });
+    expect(tasksToCsv([t3])).toContain('"첫줄\n둘째줄"');
+  });
+
+  it('계층 입력이 뒤섞여도 DFS(부모 → 자식 → 손자) 순서로 직렬화', () => {
+    const p = makeTask({ id: 'p', title: 'P' });
+    const c = makeTask({
+      id: 'c',
+      title: 'C',
+      parentId: 'p',
+      createdAt: new Date('2026-04-02T00:00:00Z'),
+    });
+    const g = makeTask({
+      id: 'g',
+      title: 'G',
+      parentId: 'c',
+      createdAt: new Date('2026-04-03T00:00:00Z'),
+    });
+    const lines = tasksToCsv([g, c, p]).split('\r\n');
+    expect(lines[1].startsWith('P,')).toBe(true);
+    expect(lines[2].startsWith('C,')).toBe(true);
+    expect(lines[3].startsWith('G,')).toBe(true);
+  });
+
+  it('null 날짜 → 빈 문자열로 직렬화', () => {
+    const t = makeTask({
+      id: 'a',
+      title: 'X',
+      startDate: null,
+      dueDate: null,
+    });
+    const lines = tasksToCsv([t]).split('\r\n');
+    expect(lines[1]).toBe('X,,,할 일,0,,,');
+  });
+});

--- a/lib/csv/parse.ts
+++ b/lib/csv/parse.ts
@@ -1,0 +1,32 @@
+import type { Task } from '@/lib/db/schema';
+
+export type ParentRef =
+  | { kind: 'existing'; id: string }
+  | { kind: 'csvRow'; toAddIndex: number }
+  | null;
+
+export type PreviewRow = {
+  title: string;
+  description: string | null;
+  assignee: string | null;
+  status: 'todo' | 'doing' | 'done';
+  progress: number;
+  startDate: string | null;
+  dueDate: string | null;
+  parent: ParentRef;
+};
+
+export type SkipReason = {
+  rowIndex: number; // 1-based (헤더 제외 데이터 행 번호)
+  reason: string;
+};
+
+export type PreviewResult = {
+  toAdd: PreviewRow[];
+  skipped: SkipReason[];
+};
+
+export function previewCsvImport(_text: string, _existing: Task[]): PreviewResult {
+  // RED 스텁 — GREEN 단계에서 실제 파서 + 규칙 적용으로 교체.
+  throw new Error('not implemented');
+}

--- a/lib/csv/parse.ts
+++ b/lib/csv/parse.ts
@@ -17,7 +17,7 @@ export type PreviewRow = {
 };
 
 export type SkipReason = {
-  rowIndex: number; // 1-based (헤더 제외 데이터 행 번호)
+  rowIndex: number; // 1-based (헤더 제외)
   reason: string;
 };
 
@@ -26,7 +26,150 @@ export type PreviewResult = {
   skipped: SkipReason[];
 };
 
-export function previewCsvImport(_text: string, _existing: Task[]): PreviewResult {
-  // RED 스텁 — GREEN 단계에서 실제 파서 + 규칙 적용으로 교체.
-  throw new Error('not implemented');
+// SPEC §6 F-2 에 따라 상태 라벨을 관대하게 매핑 — 한글 라벨 + 영문 코드 모두 허용.
+const LABEL_TO_STATUS: Record<string, PreviewRow['status']> = {
+  '할 일': 'todo',
+  '진행 중': 'doing',
+  완료: 'done',
+  todo: 'todo',
+  doing: 'doing',
+  done: 'done',
+};
+
+const ISO_DATE = /^\d{4}-\d{2}-\d{2}$/;
+
+// RFC 4180 파서 — quoted 필드 내부의 쉼표·CR·LF·"" 이스케이프 지원.
+function parseRows(text: string): string[][] {
+  const rows: string[][] = [];
+  let row: string[] = [];
+  let field = '';
+  let inQuotes = false;
+  let i = 0;
+  while (i < text.length) {
+    const c = text[i];
+    if (inQuotes) {
+      if (c === '"') {
+        if (text[i + 1] === '"') {
+          field += '"';
+          i += 2;
+          continue;
+        }
+        inQuotes = false;
+        i++;
+      } else {
+        field += c;
+        i++;
+      }
+    } else {
+      if (c === '"') {
+        inQuotes = true;
+        i++;
+      } else if (c === ',') {
+        row.push(field);
+        field = '';
+        i++;
+      } else if (c === '\r') {
+        row.push(field);
+        rows.push(row);
+        row = [];
+        field = '';
+        if (text[i + 1] === '\n') i += 2;
+        else i++;
+      } else if (c === '\n') {
+        row.push(field);
+        rows.push(row);
+        row = [];
+        field = '';
+        i++;
+      } else {
+        field += c;
+        i++;
+      }
+    }
+  }
+  // 마지막 필드 flush (trailing newline 이 없는 경우)
+  if (field !== '' || row.length > 0) {
+    row.push(field);
+    rows.push(row);
+  }
+  return rows;
+}
+
+function normalizeStatus(raw: string): PreviewRow['status'] {
+  return LABEL_TO_STATUS[raw.trim()] ?? 'todo';
+}
+
+function normalizeDate(raw: string): string | null {
+  const trimmed = raw.trim();
+  if (trimmed === '') return null;
+  return ISO_DATE.test(trimmed) ? trimmed : null;
+}
+
+function normalizeNullableString(raw: string): string | null {
+  return raw === '' ? null : raw;
+}
+
+function normalizeProgress(raw: string): number {
+  const n = Number(raw.trim());
+  if (!Number.isFinite(n)) return 0;
+  return n;
+}
+
+export function previewCsvImport(text: string, existing: Task[]): PreviewResult {
+  const rows = parseRows(text);
+  if (rows.length === 0) return { toAdd: [], skipped: [] };
+
+  // rows[0] 는 헤더로 가정. 데이터 행은 rows[1..].
+  const dataRows = rows.slice(1);
+
+  const existingByTitle = new Map<string, Task>();
+  for (const t of existing) {
+    if (!existingByTitle.has(t.title)) existingByTitle.set(t.title, t);
+  }
+
+  const toAdd: PreviewRow[] = [];
+  const skipped: SkipReason[] = [];
+  const addedIndexByTitle = new Map<string, number>();
+
+  dataRows.forEach((row, idx) => {
+    const rowIndex = idx + 1; // 1-based
+    // 8 열 미만이면 뒤를 빈 문자열로 채움
+    const col = (i: number): string => (row[i] ?? '').toString();
+    const title = col(0).trim();
+    if (title === '') {
+      skipped.push({ rowIndex, reason: '제목이 비어 있음' });
+      return;
+    }
+
+    const parentTitle = col(7).trim();
+    let parent: ParentRef = null;
+    if (parentTitle !== '') {
+      // 우선순위: (1) CSV 내 이전 행 (2) 기존 DB task.
+      const csvIdx = addedIndexByTitle.get(parentTitle);
+      if (csvIdx !== undefined) {
+        parent = { kind: 'csvRow', toAddIndex: csvIdx };
+      } else {
+        const ex = existingByTitle.get(parentTitle);
+        if (ex) parent = { kind: 'existing', id: ex.id };
+      }
+    }
+
+    const preview: PreviewRow = {
+      title,
+      description: normalizeNullableString(col(1)),
+      assignee: normalizeNullableString(col(2)),
+      status: normalizeStatus(col(3)),
+      progress: normalizeProgress(col(4)),
+      startDate: normalizeDate(col(5)),
+      dueDate: normalizeDate(col(6)),
+      parent,
+    };
+
+    const newIndex = toAdd.length;
+    toAdd.push(preview);
+    // 동명 부모 → "먼저 매칭" 원칙: 이미 등록된 제목은 덮어쓰지 않음.
+    if (!addedIndexByTitle.has(title)) addedIndexByTitle.set(title, newIndex);
+  });
+
+  return { toAdd, skipped };
 }

--- a/lib/csv/serialize.ts
+++ b/lib/csv/serialize.ts
@@ -1,6 +1,51 @@
 import type { Task } from '@/lib/db/schema';
+import { buildTaskTree, type TaskNode } from '@/lib/tasks/build-tree';
 
-export function tasksToCsv(_tasks: Task[]): string {
-  // RED 스텁 — GREEN 단계에서 실제 직렬화 로직으로 교체.
-  throw new Error('not implemented');
+const HEADER = ['제목', '설명', '담당자', '상태', '진행률', '시작일', '목표 기한', '상위 작업 제목'];
+
+const STATUS_LABEL: Record<string, string> = {
+  todo: '할 일',
+  doing: '진행 중',
+  done: '완료',
+};
+
+function escape(value: string): string {
+  // RFC 4180 — 쉼표·따옴표·CR·LF 포함 시 전체를 따옴표로 감싸고, 내부 따옴표는 "" 로 이스케이프.
+  if (value.includes(',') || value.includes('"') || value.includes('\n') || value.includes('\r')) {
+    return `"${value.replace(/"/g, '""')}"`;
+  }
+  return value;
+}
+
+function flattenDfs(nodes: TaskNode[]): Task[] {
+  const out: Task[] = [];
+  const walk = (n: TaskNode): void => {
+    out.push(n.task);
+    for (const c of n.children) walk(c);
+  };
+  for (const n of nodes) walk(n);
+  return out;
+}
+
+export function tasksToCsv(tasks: Task[]): string {
+  const byId = new Map(tasks.map((t) => [t.id, t]));
+  const ordered = flattenDfs(buildTaskTree(tasks));
+
+  const rows: string[] = [HEADER.join(',')];
+  for (const t of ordered) {
+    const parentTitle = t.parentId ? (byId.get(t.parentId)?.title ?? '') : '';
+    const statusLabel = STATUS_LABEL[t.status] ?? t.status;
+    const values = [
+      t.title,
+      t.description ?? '',
+      t.assignee ?? '',
+      statusLabel,
+      String(t.progress),
+      t.startDate ?? '',
+      t.dueDate ?? '',
+      parentTitle,
+    ];
+    rows.push(values.map(escape).join(','));
+  }
+  return rows.join('\r\n');
 }

--- a/lib/csv/serialize.ts
+++ b/lib/csv/serialize.ts
@@ -1,0 +1,6 @@
+import type { Task } from '@/lib/db/schema';
+
+export function tasksToCsv(_tasks: Task[]): string {
+  // RED 스텁 — GREEN 단계에서 실제 직렬화 로직으로 교체.
+  throw new Error('not implemented');
+}

--- a/tests/integration/actions/csv.test.ts
+++ b/tests/integration/actions/csv.test.ts
@@ -1,0 +1,88 @@
+/**
+ * RED: applyCsvImport (Issue #6 Stage 4, SPEC §6 F-2).
+ * DB 통합: 각 테스트 전 TRUNCATE.
+ */
+import { describe, it, expect, beforeAll, afterAll, beforeEach, vi } from 'vitest';
+
+vi.mock('next/cache', () => ({
+  revalidatePath: vi.fn(),
+}));
+
+import postgres from 'postgres';
+import { applyCsvImport } from '@/app/actions/csv';
+import { createTask } from '@/app/actions/tasks';
+
+const connectionString = process.env.DATABASE_URL!;
+let sql: ReturnType<typeof postgres>;
+
+const HEADER = '제목,설명,담당자,상태,진행률,시작일,목표 기한,상위 작업 제목';
+
+beforeAll(() => {
+  sql = postgres(connectionString, { prepare: false, max: 1, onnotice: () => {} });
+});
+
+afterAll(async () => {
+  await sql.end();
+});
+
+beforeEach(async () => {
+  await sql`TRUNCATE tasks RESTART IDENTITY CASCADE`;
+});
+
+describe('applyCsvImport', () => {
+  it('정상 CSV → toAdd 순서대로 insert, CSV 내부 parent 연결 유지', async () => {
+    const csv = `${HEADER}\r\nParent,,,할 일,0,,,\r\nChild,,,할 일,0,,,Parent`;
+    const result = await applyCsvImport(csv);
+    expect(result.addedCount).toBe(2);
+    expect(result.skippedCount).toBe(0);
+
+    const rows = await sql<{ id: string; title: string; parent_id: string | null }[]>`
+      SELECT id, title, parent_id FROM tasks ORDER BY created_at ASC
+    `;
+    expect(rows.map((r) => r.title)).toEqual(['Parent', 'Child']);
+    expect(rows[0].parent_id).toBeNull();
+    expect(rows[1].parent_id).toBe(rows[0].id);
+  });
+
+  it('제목 빈 행은 skip, DB 에 영향 없음', async () => {
+    const csv = `${HEADER}\r\n,빈 제목,,할 일,0,,,\r\nValid,,,할 일,0,,,`;
+    const result = await applyCsvImport(csv);
+    expect(result.addedCount).toBe(1);
+    expect(result.skippedCount).toBe(1);
+    expect(result.skipReasons[0]).toMatch(/제목/);
+
+    const rows = await sql<{ title: string }[]>`SELECT title FROM tasks`;
+    expect(rows.map((r) => r.title)).toEqual(['Valid']);
+  });
+
+  it('결과 구조: addedCount · skippedCount · skipReasons', async () => {
+    const csv = `${HEADER}\r\nX,,,할 일,0,,,`;
+    const result = await applyCsvImport(csv);
+    expect(result).toMatchObject({
+      addedCount: 1,
+      skippedCount: 0,
+      skipReasons: [],
+    });
+  });
+
+  it('기존 task 는 수정·삭제하지 않음 (SPEC F-2 "추가만")', async () => {
+    await createTask({ title: 'Keep' });
+    const csv = `${HEADER}\r\nNew,,,할 일,0,,,`;
+    await applyCsvImport(csv);
+    const rows = await sql<{ title: string }[]>`
+      SELECT title FROM tasks ORDER BY created_at ASC
+    `;
+    expect(rows.map((r) => r.title)).toEqual(['Keep', 'New']);
+  });
+
+  it('일부 행 CHECK 위반 → 해당 행만 skip, 나머지는 insert (부분 실패 허용)', async () => {
+    // progress=200 은 tasks_progress_check 위반 → DB 거부
+    const csv = `${HEADER}\r\nBad,,,할 일,200,,,\r\nGood,,,할 일,50,,,`;
+    const result = await applyCsvImport(csv);
+    expect(result.addedCount).toBe(1);
+    expect(result.skippedCount).toBe(1);
+
+    const rows = await sql<{ title: string }[]>`SELECT title FROM tasks`;
+    expect(rows.map((r) => r.title)).toEqual(['Good']);
+  });
+});

--- a/tests/integration/api/csv-export.test.ts
+++ b/tests/integration/api/csv-export.test.ts
@@ -1,0 +1,55 @@
+/**
+ * RED: GET /api/csv/export (Issue #6 Stage 3, SPEC §6 F-1).
+ * 로컬 Supabase Postgres 에 실제 연결. 각 테스트 전 `TRUNCATE tasks RESTART IDENTITY CASCADE`.
+ */
+import { describe, it, expect, beforeAll, afterAll, beforeEach, vi } from 'vitest';
+
+vi.mock('next/cache', () => ({
+  revalidatePath: vi.fn(),
+}));
+
+import postgres from 'postgres';
+import { GET } from '@/app/api/csv/export/route';
+import { createTask } from '@/app/actions/tasks';
+
+const connectionString = process.env.DATABASE_URL!;
+let sql: ReturnType<typeof postgres>;
+
+beforeAll(() => {
+  sql = postgres(connectionString, { prepare: false, max: 1, onnotice: () => {} });
+});
+
+afterAll(async () => {
+  await sql.end();
+});
+
+beforeEach(async () => {
+  await sql`TRUNCATE tasks RESTART IDENTITY CASCADE`;
+});
+
+describe('GET /api/csv/export', () => {
+  it('200 + Content-Type: text/csv', async () => {
+    const response = await GET();
+    expect(response.status).toBe(200);
+    expect(response.headers.get('Content-Type') ?? '').toMatch(/text\/csv/);
+  });
+
+  it("Content-Disposition: attachment; filename=\"wbs-YYYY-MM-DD.csv\" (오늘 날짜)", async () => {
+    const response = await GET();
+    const disposition = response.headers.get('Content-Disposition') ?? '';
+    const today = new Date().toISOString().slice(0, 10);
+    expect(disposition).toContain('attachment');
+    expect(disposition).toContain(`wbs-${today}.csv`);
+  });
+
+  it('body 가 헤더 + 모든 tasks 를 포함 (tasksToCsv 결과와 동일 구조)', async () => {
+    await createTask({ title: '킥오프' });
+    await createTask({ title: '리서치', assignee: '김PM' });
+    const response = await GET();
+    const body = await response.text();
+    expect(body).toContain('제목,설명,담당자,상태,진행률,시작일,목표 기한,상위 작업 제목');
+    expect(body).toContain('킥오프');
+    expect(body).toContain('리서치');
+    expect(body).toContain('김PM');
+  });
+});


### PR DESCRIPTION
## Summary
- SPEC.md §6 F-1·F-2 근거로 CSV 내보내기·가져오기 전 플로우 구현
- **TDD 6단계** — 각 단계가 RED → GREEN 커밋 쌍
- 직렬화·파싱은 **순수 함수**, Export = Route Handler, Import = Server Action
- 기존 CRUD · 계층 · 상태 규칙은 건드리지 않고 얹음

## 단계별 진행

| 단계 | 결과 |
|---|---|
| 1. `tasksToCsv` | 유닛 8 |
| 2. `previewCsvImport` | 유닛 10 |
| 3. `/api/csv/export` Route Handler | 통합 3 |
| 4. `applyCsvImport` Server Action | 통합 5 |
| 5. `CsvToolbar` + 페이지 배선 | 컴포넌트 4 |
| 6. Playwright 스모크 | E2E 3 |

**전체**: 유닛 92 · 통합 42 passed · tsc · lint · build 깨끗

## 아키텍처 결정
- RFC 4180 규칙 (쉼표·따옴표·CR/LF 이스케이프) · 라인 구분자 `\r\n` · 외부 라이브러리 없음
- 상태 열: 한글 라벨 우선 (`할 일` · `진행 중` · `완료`) + 영문 코드 fallback
- `buildTaskTree` 의 DFS flatten 을 export 에 재사용
- `PreviewRow.parent` 는 `'existing' | 'csvRow' | null` discriminated union
- 부모 매칭 우선순위: (1) CSV 내 이전 행 (2) 기존 DB task (3) null
- Import 부분 실패 허용 — 한 행 실패해도 나머지 insert 계속, skipReasons 에 누적
- CsvToolbar 상태 머신: `idle → preview → done`
- 파일 업로드: 숨겨진 `<input type=file>` + `aria-label="CSV 파일 선택"`

## Test plan
- [x] 유닛 `npm test` — 92 passed
- [x] 통합 `npm run test:integration` — 42 passed
- [x] `npx tsc --noEmit` / `npm run lint` / `npm run build` 모두 깨끗
- [x] Playwright MCP 스모크:
  - [x] 작업 3개(계층 2단계) 생성 → `curl /api/csv/export` → 헤더 + 3행 + 파일명 `wbs-2026-04-24.csv` 확인
  - [x] DB 비우고 업로드 → 미리보기 "3개 추가 · 제외 0건" → 적용 → 목록 재현 + 계층 유지
  - [x] 제목 빈 행 + 잘못된 날짜 CSV → "2개 추가 · 제외 1건" + 제외 사유 리스트

## 범위 밖 (후속)
- XLSX 직접 지원 / 업데이트·삭제 / 원자적 롤백 / 대용량 스트리밍
- 간트 export → Issue #7
- Overdue 정보 → Issue #11

Closes #6

🤖 Generated with [Claude Code](https://claude.com/claude-code)