### PR TITLE
feat: #7 간트 일정 시각화 뷰 (TDD 4 stages + Playwright)

### DIFF
--- a/components/__tests__/gantt-bar.test.tsx
+++ b/components/__tests__/gantt-bar.test.tsx
@@ -1,0 +1,81 @@
+/**
+ * RED: GanttBar (Issue #7 Stage 2, SPEC §7 G-2).
+ */
+import { describe, it, expect } from 'vitest';
+import { screen } from '@testing-library/react';
+import { GanttBar } from '../gantt-bar';
+import { renderWithChakra } from './helpers';
+import type { GanttRange } from '@/lib/gantt/calc';
+
+const range: GanttRange = {
+  start: new Date('2026-05-01T00:00:00Z'),
+  end: new Date('2026-05-31T00:00:00Z'),
+};
+
+describe('<GanttBar />', () => {
+  it('startDate 만 있고 dueDate 없음 → "— 일정 없음 —"', () => {
+    renderWithChakra(
+      <GanttBar startDate="2026-05-01" dueDate={null} progress={0} range={range} />,
+    );
+    expect(screen.getByText(/일정 없음/)).toBeInTheDocument();
+  });
+
+  it('dueDate 만 있고 startDate 없음 → "— 일정 없음 —"', () => {
+    renderWithChakra(
+      <GanttBar startDate={null} dueDate="2026-05-31" progress={0} range={range} />,
+    );
+    expect(screen.getByText(/일정 없음/)).toBeInTheDocument();
+  });
+
+  it('둘 다 있음 → data-left-pct · data-width-pct 속성 렌더', () => {
+    const { container } = renderWithChakra(
+      <GanttBar
+        startDate="2026-05-01"
+        dueDate="2026-05-31"
+        progress={50}
+        range={range}
+      />,
+    );
+    const bar = container.querySelector('[data-left-pct]');
+    expect(bar).not.toBeNull();
+    expect(bar!.getAttribute('data-width-pct')).not.toBeNull();
+    // 일정 없음 문구는 없어야 함
+    expect(screen.queryByText(/일정 없음/)).toBeNull();
+  });
+
+  it('진행률 0% → data-progress-pct="0"', () => {
+    const { container } = renderWithChakra(
+      <GanttBar
+        startDate="2026-05-01"
+        dueDate="2026-05-31"
+        progress={0}
+        range={range}
+      />,
+    );
+    expect(container.querySelector('[data-progress-pct]')?.getAttribute('data-progress-pct')).toBe('0');
+  });
+
+  it('진행률 100% → data-progress-pct="100"', () => {
+    const { container } = renderWithChakra(
+      <GanttBar
+        startDate="2026-05-01"
+        dueDate="2026-05-31"
+        progress={100}
+        range={range}
+      />,
+    );
+    expect(container.querySelector('[data-progress-pct]')?.getAttribute('data-progress-pct')).toBe('100');
+  });
+
+  it('진행률 60% → data-progress-pct="60"', () => {
+    const { container } = renderWithChakra(
+      <GanttBar
+        startDate="2026-05-01"
+        dueDate="2026-05-31"
+        progress={60}
+        range={range}
+      />,
+    );
+    expect(container.querySelector('[data-progress-pct]')?.getAttribute('data-progress-pct')).toBe('60');
+  });
+});

--- a/components/__tests__/gantt-view.test.tsx
+++ b/components/__tests__/gantt-view.test.tsx
@@ -1,0 +1,103 @@
+/**
+ * RED: GanttView (Issue #7 Stage 3, SPEC §7 G-2).
+ */
+import { describe, it, expect } from 'vitest';
+import { screen } from '@testing-library/react';
+import { GanttView } from '../gantt-view';
+import { renderWithChakra } from './helpers';
+import type { Task } from '@/lib/db/schema';
+
+function makeTask(overrides: Partial<Task> & { id: string; title: string }): Task {
+  return {
+    id: overrides.id,
+    parentId: overrides.parentId ?? null,
+    title: overrides.title,
+    description: null,
+    assignee: null,
+    status: 'todo',
+    progress: overrides.progress ?? 0,
+    startDate: overrides.startDate ?? null,
+    dueDate: overrides.dueDate ?? null,
+    createdAt: overrides.createdAt ?? new Date('2026-04-01T00:00:00Z'),
+    updatedAt: overrides.updatedAt ?? new Date('2026-04-01T00:00:00Z'),
+  };
+}
+
+describe('<GanttView />', () => {
+  it('tasks=[] → 빈 상태 문구', () => {
+    renderWithChakra(<GanttView tasks={[]} />);
+    expect(screen.getByText(/아직 작업이 없습니다/)).toBeInTheDocument();
+  });
+
+  it('3 tasks (계층) → DFS 순서로 3행 렌더', () => {
+    const p = makeTask({ id: 'p', title: 'Parent' });
+    const c = makeTask({
+      id: 'c',
+      title: 'Child',
+      parentId: 'p',
+      createdAt: new Date('2026-04-02T00:00:00Z'),
+    });
+    const g = makeTask({
+      id: 'g',
+      title: 'Grandchild',
+      parentId: 'c',
+      createdAt: new Date('2026-04-03T00:00:00Z'),
+    });
+    renderWithChakra(<GanttView tasks={[p, c, g]} />);
+    expect(screen.getByText('Parent')).toBeInTheDocument();
+    expect(screen.getByText('Child')).toBeInTheDocument();
+    expect(screen.getByText('Grandchild')).toBeInTheDocument();
+  });
+
+  it('주 단위 눈금 헤더 텍스트 렌더 (월/일)', () => {
+    const t = makeTask({
+      id: 'a',
+      title: 'X',
+      startDate: '2026-05-01',
+      dueDate: '2026-05-31',
+    });
+    renderWithChakra(<GanttView tasks={[t]} />);
+    // range ≈ 2026-04-24 ~ 2026-06-07, weekMarks: 4/27, 5/4, 5/11, 5/18, 5/25, 6/1
+    expect(screen.getByText('5/4')).toBeInTheDocument();
+    expect(screen.getByText('5/11')).toBeInTheDocument();
+  });
+
+  it('오늘이 range 안 → today-line 엘리먼트 존재', () => {
+    const t = makeTask({
+      id: 'a',
+      title: 'X',
+      startDate: '2026-05-01',
+      dueDate: '2026-05-31',
+    });
+    const now = new Date('2026-05-14T00:00:00Z');
+    const { container } = renderWithChakra(<GanttView tasks={[t]} now={now} />);
+    expect(container.querySelector('[data-testid="today-line"]')).not.toBeNull();
+  });
+
+  it('오늘이 range 밖 → today-line 없음', () => {
+    const t = makeTask({
+      id: 'a',
+      title: 'X',
+      startDate: '2026-05-01',
+      dueDate: '2026-05-31',
+    });
+    const now = new Date('2027-01-01T00:00:00Z');
+    const { container } = renderWithChakra(<GanttView tasks={[t]} now={now} />);
+    expect(container.querySelector('[data-testid="today-line"]')).toBeNull();
+  });
+
+  it('각 행에 data-depth 속성 (계층 들여쓰기)', () => {
+    const p = makeTask({ id: 'p', title: 'Parent' });
+    const c = makeTask({
+      id: 'c',
+      title: 'Child',
+      parentId: 'p',
+      createdAt: new Date('2026-04-02T00:00:00Z'),
+    });
+    const { container } = renderWithChakra(<GanttView tasks={[p, c]} />);
+    const depthNodes = container.querySelectorAll('[data-depth]');
+    const depths = Array.from(depthNodes).map((n) => n.getAttribute('data-depth'));
+    expect(depths).toContain('0');
+    expect(depths).toContain('1');
+  });
+});

--- a/components/__tests__/tasks-page-client.test.tsx
+++ b/components/__tests__/tasks-page-client.test.tsx
@@ -1,0 +1,84 @@
+/**
+ * RED: TasksPageClient 뷰 토글 (Issue #7 Stage 4, SPEC §7 G-1).
+ * Server Actions 는 vi.mock 으로 noop 처리해 UI 동작만 검증.
+ */
+import { describe, it, expect, vi } from 'vitest';
+import { screen, fireEvent } from '@testing-library/react';
+import { renderWithChakra } from './helpers';
+import type { Task } from '@/lib/db/schema';
+
+vi.mock('@/app/actions/tasks', () => ({
+  createTask: vi.fn(),
+  updateTask: vi.fn(),
+  deleteTask: vi.fn(),
+  getDescendantCount: vi.fn().mockResolvedValue(0),
+}));
+
+vi.mock('@/app/actions/csv', () => ({
+  applyCsvImport: vi.fn(),
+}));
+
+import { TasksPageClient } from '../tasks-page-client';
+
+function makeTask(overrides: Partial<Task> & { id: string; title: string }): Task {
+  return {
+    id: overrides.id,
+    parentId: overrides.parentId ?? null,
+    title: overrides.title,
+    description: null,
+    assignee: null,
+    status: 'todo',
+    progress: overrides.progress ?? 0,
+    startDate: overrides.startDate ?? null,
+    dueDate: overrides.dueDate ?? null,
+    createdAt: overrides.createdAt ?? new Date('2026-04-01T00:00:00Z'),
+    updatedAt: overrides.updatedAt ?? new Date('2026-04-01T00:00:00Z'),
+  };
+}
+
+describe('<TasksPageClient /> 뷰 토글 (Stage 4)', () => {
+  it('초기 렌더 → 목록 뷰 활성 + 토글 버튼 2개 존재', () => {
+    renderWithChakra(<TasksPageClient initialTasks={[]} />);
+    expect(screen.getByRole('button', { name: '목록' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: '간트' })).toBeInTheDocument();
+    expect(screen.getByText(/아직 작업이 없습니다/)).toBeInTheDocument();
+  });
+
+  it('"간트" 클릭 → GanttView 렌더, TaskList 의 row 버튼 사라짐', () => {
+    const t = makeTask({
+      id: 'a',
+      title: 'MyTask',
+      startDate: '2026-05-01',
+      dueDate: '2026-05-31',
+    });
+    renderWithChakra(<TasksPageClient initialTasks={[t]} />);
+    // 초기: TaskList 에 의해 role=button 이름='작업: MyTask' 있음
+    expect(screen.getByRole('button', { name: '작업: MyTask' })).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: '간트' }));
+    // TaskList 의 row 버튼은 사라짐
+    expect(screen.queryByRole('button', { name: '작업: MyTask' })).toBeNull();
+    // GanttView 에서 타이틀은 Text 로 표시
+    expect(screen.getByText('MyTask')).toBeInTheDocument();
+  });
+
+  it('"목록" 클릭 → 다시 TaskList row 버튼 복귀', () => {
+    const t = makeTask({ id: 'a', title: 'MyTask' });
+    renderWithChakra(<TasksPageClient initialTasks={[t]} />);
+    fireEvent.click(screen.getByRole('button', { name: '간트' }));
+    fireEvent.click(screen.getByRole('button', { name: '목록' }));
+    expect(screen.getByRole('button', { name: '작업: MyTask' })).toBeInTheDocument();
+  });
+
+  it('툴바(+ 작업 추가 · CSV 내보내기/불러오기) 는 두 뷰 모두에서 유지', () => {
+    renderWithChakra(<TasksPageClient initialTasks={[]} />);
+    // 목록 뷰
+    expect(screen.getByRole('button', { name: '+ 작업 추가' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'CSV 내보내기' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'CSV 불러오기' })).toBeInTheDocument();
+    // 간트 뷰로 전환
+    fireEvent.click(screen.getByRole('button', { name: '간트' }));
+    expect(screen.getByRole('button', { name: '+ 작업 추가' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'CSV 내보내기' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'CSV 불러오기' })).toBeInTheDocument();
+  });
+});

--- a/components/gantt-bar.tsx
+++ b/components/gantt-bar.tsx
@@ -1,6 +1,7 @@
 'use client';
 
-import type { GanttRange } from '@/lib/gantt/calc';
+import { Box, Text } from '@chakra-ui/react';
+import { calculateBar, type GanttRange } from '@/lib/gantt/calc';
 
 export type GanttBarProps = {
   startDate: string | null;
@@ -9,7 +10,39 @@ export type GanttBarProps = {
   range: GanttRange;
 };
 
-export function GanttBar(_props: GanttBarProps) {
-  // RED 스텁 — GREEN 단계에서 실제 막대 렌더링으로 교체.
-  return null;
+export function GanttBar({ startDate, dueDate, progress, range }: GanttBarProps) {
+  // SPEC §7 G-2: 시작일/목표 기한 중 하나라도 비면 막대 없이 "— 일정 없음 —" 표기.
+  if (!startDate || !dueDate) {
+    return (
+      <Text fontSize="sm" color="fg.muted" textAlign="center">
+        — 일정 없음 —
+      </Text>
+    );
+  }
+
+  const bar = calculateBar(startDate, dueDate, progress, range);
+
+  return (
+    <Box
+      position="absolute"
+      top="50%"
+      transform="translateY(-50%)"
+      left={`${bar.leftPct}%`}
+      width={`${bar.widthPct}%`}
+      height="20px"
+      borderRadius="sm"
+      bg="blue.100"
+      overflow="hidden"
+      data-left-pct={String(bar.leftPct)}
+      data-width-pct={String(bar.widthPct)}
+      data-progress-pct={String(bar.progressPct)}
+    >
+      {/* 진행률 채움 — SPEC §7 G-2 "진행률만큼 진한 색, 나머지는 옅은 색" */}
+      <Box
+        width={`${bar.progressPct}%`}
+        height="100%"
+        bg="blue.500"
+      />
+    </Box>
+  );
 }

--- a/components/gantt-bar.tsx
+++ b/components/gantt-bar.tsx
@@ -1,0 +1,15 @@
+'use client';
+
+import type { GanttRange } from '@/lib/gantt/calc';
+
+export type GanttBarProps = {
+  startDate: string | null;
+  dueDate: string | null;
+  progress: number;
+  range: GanttRange;
+};
+
+export function GanttBar(_props: GanttBarProps) {
+  // RED 스텁 — GREEN 단계에서 실제 막대 렌더링으로 교체.
+  return null;
+}

--- a/components/gantt-view.tsx
+++ b/components/gantt-view.tsx
@@ -1,0 +1,13 @@
+'use client';
+
+import type { Task } from '@/lib/db/schema';
+
+export type GanttViewProps = {
+  tasks: Task[];
+  now?: Date;
+};
+
+export function GanttView(_props: GanttViewProps) {
+  // RED 스텁 — GREEN 단계에서 좌측 트리 + 우측 그리드 + 오늘선으로 교체.
+  return null;
+}

--- a/components/gantt-view.tsx
+++ b/components/gantt-view.tsx
@@ -1,13 +1,133 @@
 'use client';
 
+import { Box, Flex, Text } from '@chakra-ui/react';
 import type { Task } from '@/lib/db/schema';
+import { calculateRange, getWeekMarks, type GanttRange } from '@/lib/gantt/calc';
+import { buildTaskTree, type TaskNode } from '@/lib/tasks/build-tree';
+import { GanttBar } from './gantt-bar';
 
 export type GanttViewProps = {
   tasks: Task[];
   now?: Date;
 };
 
-export function GanttView(_props: GanttViewProps) {
-  // RED 스텁 — GREEN 단계에서 좌측 트리 + 우측 그리드 + 오늘선으로 교체.
-  return null;
+const LEFT_COL_WIDTH = '240px';
+const ROW_HEIGHT = '36px';
+
+function flattenTree(nodes: TaskNode[]): TaskNode[] {
+  const out: TaskNode[] = [];
+  const walk = (n: TaskNode): void => {
+    out.push(n);
+    for (const c of n.children) walk(c);
+  };
+  for (const n of nodes) walk(n);
+  return out;
+}
+
+function formatWeekLabel(d: Date): string {
+  return `${d.getUTCMonth() + 1}/${d.getUTCDate()}`;
+}
+
+function pctOfRange(d: Date, range: GanttRange): number {
+  const total = range.end.getTime() - range.start.getTime();
+  return ((d.getTime() - range.start.getTime()) / total) * 100;
+}
+
+export function GanttView({ tasks, now = new Date() }: GanttViewProps) {
+  if (tasks.length === 0) {
+    return (
+      <Box py={10} textAlign="center">
+        <Text color="fg.muted">아직 작업이 없습니다. 첫 작업을 추가해 시작하세요</Text>
+      </Box>
+    );
+  }
+
+  const range = calculateRange(tasks, now);
+  const flat = flattenTree(buildTaskTree(tasks));
+  const weekMarks = getWeekMarks(range);
+
+  const nowMs = now.getTime();
+  const todayInRange = nowMs >= range.start.getTime() && nowMs <= range.end.getTime();
+  const todayPct = todayInRange ? pctOfRange(now, range) : null;
+
+  return (
+    <Flex borderWidth="1px" borderRadius="md" overflow="hidden">
+      {/* 좌측: 작업 트리 */}
+      <Box width={LEFT_COL_WIDTH} flexShrink={0} borderRightWidth="1px">
+        {/* 헤더 높이 맞춤 */}
+        <Box h={ROW_HEIGHT} borderBottomWidth="1px" />
+        {flat.map((node) => (
+          <Flex
+            key={node.task.id}
+            h={ROW_HEIGHT}
+            alignItems="center"
+            pl={3 + node.depth * 4}
+            pr={2}
+            borderBottomWidth="1px"
+            gap={2}
+            data-depth={node.depth}
+          >
+            <Text fontSize="sm" fontWeight="medium" flex="1" truncate>
+              {node.task.title}
+            </Text>
+            <Text fontSize="xs" color="fg.muted">
+              {node.task.progress}%
+            </Text>
+          </Flex>
+        ))}
+      </Box>
+
+      {/* 우측: 날짜 그리드 + 막대 + 오늘선 */}
+      <Box flex="1" position="relative" minW="0">
+        {/* 주 단위 눈금 헤더 */}
+        <Box h={ROW_HEIGHT} borderBottomWidth="1px" position="relative">
+          {weekMarks.map((d, i) => (
+            <Text
+              key={i}
+              position="absolute"
+              left={`${pctOfRange(d, range)}%`}
+              top="50%"
+              transform="translate(-50%, -50%)"
+              fontSize="xs"
+              color="fg.muted"
+              whiteSpace="nowrap"
+            >
+              {formatWeekLabel(d)}
+            </Text>
+          ))}
+        </Box>
+
+        {/* 각 작업 행 */}
+        {flat.map((node) => (
+          <Box
+            key={node.task.id}
+            h={ROW_HEIGHT}
+            borderBottomWidth="1px"
+            position="relative"
+          >
+            <GanttBar
+              startDate={node.task.startDate}
+              dueDate={node.task.dueDate}
+              progress={node.task.progress}
+              range={range}
+            />
+          </Box>
+        ))}
+
+        {/* 오늘 세로선 overlay */}
+        {todayPct !== null && (
+          <Box
+            data-testid="today-line"
+            position="absolute"
+            top={0}
+            bottom={0}
+            left={`${todayPct}%`}
+            width="2px"
+            bg="red.500"
+            pointerEvents="none"
+          />
+        )}
+      </Box>
+    </Flex>
+  );
 }

--- a/components/tasks-page-client.tsx
+++ b/components/tasks-page-client.tsx
@@ -10,6 +10,7 @@ import { TaskList } from './task-list';
 import { TaskFormModal } from './task-form-modal';
 import { DeleteConfirmDialog } from './delete-confirm-dialog';
 import { CsvToolbar } from './csv-toolbar';
+import { GanttView } from './gantt-view';
 
 type ModalState =
   | { kind: 'none' }
@@ -19,6 +20,7 @@ type ModalState =
 
 export function TasksPageClient({ initialTasks }: { initialTasks: Task[] }) {
   const [modal, setModal] = useState<ModalState>({ kind: 'none' });
+  const [view, setView] = useState<'list' | 'gantt'>('list');
   const [, startTransition] = useTransition();
 
   const close = () => setModal({ kind: 'none' });
@@ -82,6 +84,22 @@ export function TasksPageClient({ initialTasks }: { initialTasks: Task[] }) {
       <Flex justify="space-between" align="center" mb={6} gap={4}>
         <Heading size="lg">WBS</Heading>
         <Flex gap={2} align="center">
+          <Flex gap={1} align="center">
+            <Button
+              size="sm"
+              variant={view === 'list' ? 'solid' : 'outline'}
+              onClick={() => setView('list')}
+            >
+              목록
+            </Button>
+            <Button
+              size="sm"
+              variant={view === 'gantt' ? 'solid' : 'outline'}
+              onClick={() => setView('gantt')}
+            >
+              간트
+            </Button>
+          </Flex>
           <CsvToolbar existingTasks={initialTasks} />
           <Button onClick={() => setModal({ kind: 'create', parentId: null })}>
             + 작업 추가
@@ -89,13 +107,17 @@ export function TasksPageClient({ initialTasks }: { initialTasks: Task[] }) {
         </Flex>
       </Flex>
 
-      <TaskList
-        tasks={initialTasks}
-        onRowClick={(task) => setModal({ kind: 'edit', task })}
-        onAddChildClick={(task) => setModal({ kind: 'create', parentId: task.id })}
-        onDeleteClick={(task) => void openDelete(task)}
-        onStatusCycle={handleStatusCycle}
-      />
+      {view === 'list' ? (
+        <TaskList
+          tasks={initialTasks}
+          onRowClick={(task) => setModal({ kind: 'edit', task })}
+          onAddChildClick={(task) => setModal({ kind: 'create', parentId: task.id })}
+          onDeleteClick={(task) => void openDelete(task)}
+          onStatusCycle={handleStatusCycle}
+        />
+      ) : (
+        <GanttView tasks={initialTasks} />
+      )}
 
       {modal.kind === 'create' && (
         <Box mt={6}>

--- a/lib/gantt/__tests__/calc.test.ts
+++ b/lib/gantt/__tests__/calc.test.ts
@@ -1,0 +1,102 @@
+/**
+ * RED: Gantt 유틸 (Issue #7 Stage 1, SPEC §7 G-2).
+ */
+import { describe, it, expect } from 'vitest';
+import { calculateRange, calculateBar, getWeekMarks, type GanttRange } from '@/lib/gantt/calc';
+import type { Task } from '@/lib/db/schema';
+
+function makeTask(overrides: Partial<Task> & { id: string; title: string }): Task {
+  return {
+    id: overrides.id,
+    parentId: overrides.parentId ?? null,
+    title: overrides.title,
+    description: null,
+    assignee: null,
+    status: 'todo',
+    progress: 0,
+    startDate: overrides.startDate ?? null,
+    dueDate: overrides.dueDate ?? null,
+    createdAt: new Date('2026-04-01T00:00:00Z'),
+    updatedAt: new Date('2026-04-01T00:00:00Z'),
+  };
+}
+
+describe('calculateRange', () => {
+  it('빈 배열 → 오늘 기준 전후 4주 기본 범위', () => {
+    const now = new Date('2026-05-14T00:00:00Z');
+    const range = calculateRange([], now);
+    expect(range.start.toISOString().slice(0, 10)).toBe('2026-04-16');
+    expect(range.end.toISOString().slice(0, 10)).toBe('2026-06-11');
+  });
+
+  it('날짜 있는 tasks → min(startDate)-1주 ~ max(dueDate)+1주', () => {
+    const tasks = [
+      makeTask({ id: 'a', title: 'A', startDate: '2026-05-01', dueDate: '2026-05-14' }),
+      makeTask({ id: 'b', title: 'B', startDate: '2026-05-20', dueDate: '2026-06-01' }),
+    ];
+    const range = calculateRange(tasks);
+    expect(range.start.toISOString().slice(0, 10)).toBe('2026-04-24');
+    expect(range.end.toISOString().slice(0, 10)).toBe('2026-06-08');
+  });
+
+  it('모든 task 가 날짜 null → 기본 범위', () => {
+    const tasks = [makeTask({ id: 'a', title: 'A' })];
+    const now = new Date('2026-05-14T00:00:00Z');
+    const range = calculateRange(tasks, now);
+    expect(range.start.toISOString().slice(0, 10)).toBe('2026-04-16');
+    expect(range.end.toISOString().slice(0, 10)).toBe('2026-06-11');
+  });
+});
+
+describe('calculateBar', () => {
+  const range: GanttRange = {
+    start: new Date('2026-05-01T00:00:00Z'),
+    end: new Date('2026-05-31T00:00:00Z'),
+  };
+
+  it('start=range.start · due=range.end → leftPct=0, widthPct=100', () => {
+    const bar = calculateBar('2026-05-01', '2026-05-31', 50, range);
+    expect(bar.leftPct).toBeCloseTo(0, 1);
+    expect(bar.widthPct).toBeCloseTo(100, 1);
+  });
+
+  it('progress=0 → progressPct=0', () => {
+    const bar = calculateBar('2026-05-01', '2026-05-31', 0, range);
+    expect(bar.progressPct).toBe(0);
+  });
+
+  it('progress=100 → progressPct=100', () => {
+    const bar = calculateBar('2026-05-01', '2026-05-31', 100, range);
+    expect(bar.progressPct).toBe(100);
+  });
+
+  it('절반 기간 → widthPct ≈ 50', () => {
+    const bar = calculateBar('2026-05-01', '2026-05-16', 50, range);
+    expect(bar.widthPct).toBeCloseTo(50, 0);
+  });
+});
+
+describe('getWeekMarks', () => {
+  it('월요일 기준 주 경계 반환 (range.start ≤ mark ≤ range.end)', () => {
+    const range: GanttRange = {
+      start: new Date('2026-05-01T00:00:00Z'), // Fri
+      end: new Date('2026-05-22T00:00:00Z'),   // Fri
+    };
+    const marks = getWeekMarks(range);
+    expect(marks.map((d) => d.toISOString().slice(0, 10))).toEqual([
+      '2026-05-04', // Mon
+      '2026-05-11',
+      '2026-05-18',
+    ]);
+  });
+
+  it('4주 범위 → 4~5개 mark', () => {
+    const range: GanttRange = {
+      start: new Date('2026-05-01T00:00:00Z'),
+      end: new Date('2026-05-29T00:00:00Z'), // +28 days
+    };
+    const marks = getWeekMarks(range);
+    expect(marks.length).toBeGreaterThanOrEqual(4);
+    expect(marks.length).toBeLessThanOrEqual(5);
+  });
+});

--- a/lib/gantt/calc.ts
+++ b/lib/gantt/calc.ts
@@ -7,20 +7,77 @@ export type GanttBar = {
   progressPct: number;
 };
 
-export function calculateRange(_tasks: Task[], _now?: Date): GanttRange {
-  // RED 스텁 — GREEN 단계에서 실제 범위 계산으로 교체.
-  throw new Error('not implemented');
+const ONE_DAY_MS = 24 * 60 * 60 * 1000;
+
+function parseIsoDate(s: string): Date {
+  // YYYY-MM-DD → UTC midnight.
+  return new Date(`${s}T00:00:00Z`);
+}
+
+function startOfDayUtc(date: Date): Date {
+  const d = new Date(date);
+  d.setUTCHours(0, 0, 0, 0);
+  return d;
+}
+
+function addDays(date: Date, days: number): Date {
+  return new Date(date.getTime() + days * ONE_DAY_MS);
+}
+
+function firstMondayOnOrAfter(date: Date): Date {
+  const d = startOfDayUtc(date);
+  // 0=Sun, 1=Mon, ..., 6=Sat
+  const day = d.getUTCDay();
+  const daysUntilMonday = (1 - day + 7) % 7;
+  return addDays(d, daysUntilMonday);
+}
+
+export function calculateRange(tasks: Task[], now: Date = new Date()): GanttRange {
+  const dates: Date[] = [];
+  for (const t of tasks) {
+    if (t.startDate) dates.push(parseIsoDate(t.startDate));
+    if (t.dueDate) dates.push(parseIsoDate(t.dueDate));
+  }
+
+  if (dates.length === 0) {
+    // 기본: 오늘 ±4주.
+    const today = startOfDayUtc(now);
+    return {
+      start: addDays(today, -28),
+      end: addDays(today, 28),
+    };
+  }
+
+  const minMs = Math.min(...dates.map((d) => d.getTime()));
+  const maxMs = Math.max(...dates.map((d) => d.getTime()));
+  return {
+    start: addDays(new Date(minMs), -7),
+    end: addDays(new Date(maxMs), 7),
+  };
 }
 
 export function calculateBar(
-  _startDate: string,
-  _dueDate: string,
-  _progress: number,
-  _range: GanttRange,
+  startDate: string,
+  dueDate: string,
+  progress: number,
+  range: GanttRange,
 ): GanttBar {
-  throw new Error('not implemented');
+  const totalMs = range.end.getTime() - range.start.getTime();
+  const s = parseIsoDate(startDate).getTime() - range.start.getTime();
+  const e = parseIsoDate(dueDate).getTime() - range.start.getTime();
+  return {
+    leftPct: (s / totalMs) * 100,
+    widthPct: ((e - s) / totalMs) * 100,
+    progressPct: Math.max(0, Math.min(100, progress)),
+  };
 }
 
-export function getWeekMarks(_range: GanttRange): Date[] {
-  throw new Error('not implemented');
+export function getWeekMarks(range: GanttRange): Date[] {
+  const marks: Date[] = [];
+  let current = firstMondayOnOrAfter(range.start);
+  while (current.getTime() <= range.end.getTime()) {
+    marks.push(current);
+    current = addDays(current, 7);
+  }
+  return marks;
 }

--- a/lib/gantt/calc.ts
+++ b/lib/gantt/calc.ts
@@ -1,0 +1,26 @@
+import type { Task } from '@/lib/db/schema';
+
+export type GanttRange = { start: Date; end: Date };
+export type GanttBar = {
+  leftPct: number;
+  widthPct: number;
+  progressPct: number;
+};
+
+export function calculateRange(_tasks: Task[], _now?: Date): GanttRange {
+  // RED 스텁 — GREEN 단계에서 실제 범위 계산으로 교체.
+  throw new Error('not implemented');
+}
+
+export function calculateBar(
+  _startDate: string,
+  _dueDate: string,
+  _progress: number,
+  _range: GanttRange,
+): GanttBar {
+  throw new Error('not implemented');
+}
+
+export function getWeekMarks(_range: GanttRange): Date[] {
+  throw new Error('not implemented');
+}


### PR DESCRIPTION
## Summary
- SPEC.md §7 G-1·G-2·G-3 근거로 간트형 일정 시각화 뷰 구현
- **TDD 4단계 + Playwright 스모크** — 각 단계가 RED → GREEN 커밋 쌍
- 계산·UI 분리: 순수 함수 `lib/gantt/calc.ts` + 컴포넌트 `GanttBar` / `GanttView`
- 기존 CRUD · 계층 · 규칙 · CSV 에 얹는 뷰 (ViewToggle 로 전환)

## 단계별 진행

| 단계 | 결과 |
|---|---|
| 1. Gantt 유틸 (calculateRange · calculateBar · getWeekMarks) | 유닛 9 |
| 2. `GanttBar` 컴포넌트 (막대 · 진행률 · 일정 없음) | 유닛 6 |
| 3. `GanttView` 컴포넌트 (좌측 트리 · 우측 그리드 · 오늘선) | 유닛 6 |
| 4. 페이지 통합 (ViewToggle + 조건부 렌더) | 유닛 4 |
| 5. Playwright 스모크 | E2E ✓ |

**전체**: 유닛 117 · 통합 42 passed · tsc · lint · build 깨끗

## 아키텍처 결정
- Gantt 계산은 **순수 함수** (`lib/gantt/calc.ts`) · UI 독립 · 유닛 테스트 풀커버
- ISO 날짜 → UTC midnight 파싱 (timezone 독립, 결정적 테스트)
- 주 시작 = 월요일 (한국 관용), 기본 범위 = 오늘 ±4주, 날짜 있음 → min-1주 ~ max+1주
- CSS % absolute · 진행률 채움은 inner `<Box width={progressPct}%>` 실제 DOM (testing-library 친화적)
- 오늘 세로선: range 내일 때만, `data-testid="today-line"`, width 2px
- 간트 뷰 **읽기 전용** (SPEC G-3) — 드래그/클릭 핸들러 없음
- ViewToggle: 별도 컴포넌트 없이 버튼 2개, 활성 `solid` / 비활성 `outline`
- 툴바(CsvToolbar · + 작업 추가) 는 조건부 바깥에 있어 두 뷰 모두 공유

## Test plan
- [x] 유닛 `npm test` — 117 passed
- [x] 통합 `npm run test:integration` — 42 passed
- [x] `npx tsc --noEmit` / `npm run lint` / `npm run build` 모두 깨끗
- [x] Playwright MCP 스모크:
  - [x] 3 tasks 시드(킥오프 100% 4/20-4/30 · 리서치 30% 5/1-5/14 · 디자인 일정없음)
  - [x] "간트" 클릭 → 좌측 3행 · 우측 눈금(4/13, 4/20, ..., 5/18) · 막대 2개 + "— 일정 없음 —" 1개
  - [x] 킥오프 막대 전체 진한 색(100%) · 리서치 막대 내부 30% 진한 색
  - [x] 오늘 세로선(빨강) 가시 (오늘 2026-04-24, range 내부)
  - [x] "목록" 토글 → TaskList 3행 복귀

## 범위 밖 (후속)
- Overdue 막대 경고색/빗금 → **Issue #11**
- 드래그 편집 → SPEC §9
- 월/일 zoom · 간트 펼침/접힘 · date picker → polish

Closes #7

🤖 Generated with [Claude Code](https://claude.com/claude-code)