### PR TITLE
feat: #11 목표 기한 지남(overdue) 시각 표시 (TDD 3 stages + Playwright)

### DIFF
--- a/components/__tests__/gantt-bar.test.tsx
+++ b/components/__tests__/gantt-bar.test.tsx
@@ -78,4 +78,47 @@ describe('<GanttBar />', () => {
     );
     expect(container.querySelector('[data-progress-pct]')?.getAttribute('data-progress-pct')).toBe('60');
   });
+
+  describe('overdue 표시 (Stage 3, SPEC §8 H-2 간트)', () => {
+    it('overdue=true → data-overdue="true"', () => {
+      const { container } = renderWithChakra(
+        <GanttBar
+          startDate="2026-05-01"
+          dueDate="2026-05-31"
+          progress={50}
+          range={range}
+          overdue
+        />,
+      );
+      const bar = container.querySelector('[data-overdue]');
+      expect(bar?.getAttribute('data-overdue')).toBe('true');
+    });
+
+    it('overdue 기본값(생략) → data-overdue="false"', () => {
+      const { container } = renderWithChakra(
+        <GanttBar
+          startDate="2026-05-01"
+          dueDate="2026-05-31"
+          progress={50}
+          range={range}
+        />,
+      );
+      const bar = container.querySelector('[data-overdue]');
+      expect(bar?.getAttribute('data-overdue')).toBe('false');
+    });
+
+    it('"일정 없음" 분기에서는 overdue 무관 — 텍스트만 렌더, 막대 없음', () => {
+      const { container } = renderWithChakra(
+        <GanttBar
+          startDate={null}
+          dueDate="2026-05-31"
+          progress={50}
+          range={range}
+          overdue
+        />,
+      );
+      expect(screen.getByText(/일정 없음/)).toBeInTheDocument();
+      expect(container.querySelector('[data-overdue]')).toBeNull();
+    });
+  });
 });

--- a/components/__tests__/task-list.test.tsx
+++ b/components/__tests__/task-list.test.tsx
@@ -114,6 +114,95 @@ describe('<TaskList />', () => {
     });
   });
 
+  describe('기간 컬럼 + overdue (Stage 2, SPEC §1 A-2, §8 H-2)', () => {
+    it('시작일 + 목표 기한 있음 → "M/D ~ M/D" 렌더', () => {
+      const t = makeTask({
+        id: 'a',
+        title: 'X',
+        startDate: '2026-05-01',
+        dueDate: '2026-05-10',
+      });
+      renderWithChakra(
+        <TaskList tasks={[t]} onRowClick={vi.fn()} now={new Date('2026-04-01T00:00:00Z')} />,
+      );
+      expect(screen.getByTestId('task-date-range')).toHaveTextContent('5/1 ~ 5/10');
+    });
+
+    it('시작일만 있음 → "M/D ~"', () => {
+      const t = makeTask({ id: 'a', title: 'X', startDate: '2026-05-01' });
+      renderWithChakra(<TaskList tasks={[t]} onRowClick={vi.fn()} />);
+      expect(screen.getByTestId('task-date-range')).toHaveTextContent('5/1 ~');
+    });
+
+    it('목표 기한만 있음 → "~ M/D"', () => {
+      const t = makeTask({ id: 'a', title: 'X', dueDate: '2026-05-10' });
+      renderWithChakra(
+        <TaskList tasks={[t]} onRowClick={vi.fn()} now={new Date('2026-04-01T00:00:00Z')} />,
+      );
+      expect(screen.getByTestId('task-date-range')).toHaveTextContent('~ 5/10');
+    });
+
+    it('날짜 둘 다 없음 → "—"', () => {
+      const t = makeTask({ id: 'a', title: 'X' });
+      renderWithChakra(<TaskList tasks={[t]} onRowClick={vi.fn()} />);
+      expect(screen.getByTestId('task-date-range')).toHaveTextContent('—');
+    });
+
+    it('과거 목표 기한 + status=doing → "지남" 배지 + data-overdue="true"', () => {
+      const t = makeTask({
+        id: 'a',
+        title: 'X',
+        dueDate: '2026-05-01',
+        status: 'doing',
+      });
+      renderWithChakra(
+        <TaskList
+          tasks={[t]}
+          onRowClick={vi.fn()}
+          now={new Date('2026-05-10T00:00:00Z')}
+        />,
+      );
+      expect(screen.getByText('지남')).toBeInTheDocument();
+      const cell = screen.getByTestId('task-date-range').parentElement;
+      expect(cell).toHaveAttribute('data-overdue', 'true');
+    });
+
+    it('과거 목표 기한 + status=done → "지남" 배지 없음 (H-3)', () => {
+      const t = makeTask({
+        id: 'a',
+        title: 'X',
+        dueDate: '2026-05-01',
+        status: 'done',
+        progress: 100,
+      });
+      renderWithChakra(
+        <TaskList
+          tasks={[t]}
+          onRowClick={vi.fn()}
+          now={new Date('2026-05-10T00:00:00Z')}
+        />,
+      );
+      expect(screen.queryByText('지남')).toBeNull();
+    });
+
+    it('미래 목표 기한 → 경고 없음', () => {
+      const t = makeTask({
+        id: 'a',
+        title: 'X',
+        dueDate: '2026-05-20',
+        status: 'doing',
+      });
+      renderWithChakra(
+        <TaskList
+          tasks={[t]}
+          onRowClick={vi.fn()}
+          now={new Date('2026-05-10T00:00:00Z')}
+        />,
+      );
+      expect(screen.queryByText('지남')).toBeNull();
+    });
+  });
+
   describe('상태 배지 배선 (Issue #5 Stage 5, SPEC §3 C-2)', () => {
     it('onStatusCycle 없으면 배지는 한글 라벨만 읽기 전용 표시', () => {
       const t = makeTask({ id: 'x', title: 'X', status: 'todo' });

--- a/components/gantt-bar.tsx
+++ b/components/gantt-bar.tsx
@@ -8,9 +8,10 @@ export type GanttBarProps = {
   dueDate: string | null;
   progress: number;
   range: GanttRange;
+  overdue?: boolean;
 };
 
-export function GanttBar({ startDate, dueDate, progress, range }: GanttBarProps) {
+export function GanttBar({ startDate, dueDate, progress, range, overdue = false }: GanttBarProps) {
   // SPEC §7 G-2: 시작일/목표 기한 중 하나라도 비면 막대 없이 "— 일정 없음 —" 표기.
   if (!startDate || !dueDate) {
     return (
@@ -33,9 +34,13 @@ export function GanttBar({ startDate, dueDate, progress, range }: GanttBarProps)
       borderRadius="sm"
       bg="blue.100"
       overflow="hidden"
+      // SPEC §8 H-2 간트: overdue 시 빨강 테두리.
+      borderWidth={overdue ? '2px' : '0'}
+      borderColor={overdue ? 'red.500' : 'transparent'}
       data-left-pct={String(bar.leftPct)}
       data-width-pct={String(bar.widthPct)}
       data-progress-pct={String(bar.progressPct)}
+      data-overdue={String(overdue)}
     >
       {/* 진행률 채움 — SPEC §7 G-2 "진행률만큼 진한 색, 나머지는 옅은 색" */}
       <Box

--- a/components/gantt-view.tsx
+++ b/components/gantt-view.tsx
@@ -4,6 +4,7 @@ import { Box, Flex, Text } from '@chakra-ui/react';
 import type { Task } from '@/lib/db/schema';
 import { calculateRange, getWeekMarks, type GanttRange } from '@/lib/gantt/calc';
 import { buildTaskTree, type TaskNode } from '@/lib/tasks/build-tree';
+import { isOverdue } from '@/lib/overdue/is-overdue';
 import { GanttBar } from './gantt-bar';
 
 export type GanttViewProps = {
@@ -110,6 +111,7 @@ export function GanttView({ tasks, now = new Date() }: GanttViewProps) {
               dueDate={node.task.dueDate}
               progress={node.task.progress}
               range={range}
+              overdue={isOverdue(node.task.dueDate, node.task.status, now)}
             />
           </Box>
         ))}

--- a/components/task-list.tsx
+++ b/components/task-list.tsx
@@ -1,10 +1,11 @@
 'use client';
 
 import { useMemo, useState } from 'react';
-import { Box, Button, Flex, Stack, Text } from '@chakra-ui/react';
+import { Badge, Box, Button, Flex, Stack, Text } from '@chakra-ui/react';
 import type { Task } from '@/lib/db/schema';
 import type { TaskStatus } from '@/lib/validation/task';
 import { buildTaskTree, type TaskNode } from '@/lib/tasks/build-tree';
+import { isOverdue } from '@/lib/overdue/is-overdue';
 import { StatusBadge } from './status-badge';
 
 export type TaskListProps = {
@@ -13,7 +14,21 @@ export type TaskListProps = {
   onAddChildClick?: (task: Task) => void;
   onDeleteClick?: (task: Task) => void;
   onStatusCycle?: (task: Task) => void;
+  now?: Date;
 };
+
+function formatShortDate(iso: string): string {
+  // '2026-05-01' → '5/1' (선행 0 제거, 월/일 관용 포맷)
+  const d = new Date(`${iso}T00:00:00Z`);
+  return `${d.getUTCMonth() + 1}/${d.getUTCDate()}`;
+}
+
+function formatDateRange(start: string | null, due: string | null): string {
+  if (!start && !due) return '—';
+  if (!due) return `${formatShortDate(start!)} ~`;
+  if (!start) return `~ ${formatShortDate(due)}`;
+  return `${formatShortDate(start)} ~ ${formatShortDate(due)}`;
+}
 
 function flattenVisibleNodes(nodes: TaskNode[], collapsedIds: Set<string>): TaskNode[] {
   const out: TaskNode[] = [];
@@ -27,7 +42,7 @@ function flattenVisibleNodes(nodes: TaskNode[], collapsedIds: Set<string>): Task
   return out;
 }
 
-export function TaskList({ tasks, onRowClick, onAddChildClick, onDeleteClick, onStatusCycle }: TaskListProps) {
+export function TaskList({ tasks, onRowClick, onAddChildClick, onDeleteClick, onStatusCycle, now = new Date() }: TaskListProps) {
   const tree = useMemo(() => buildTaskTree(tasks), [tasks]);
   const [collapsedIds, setCollapsedIds] = useState<Set<string>>(() => new Set());
   const visibleNodes = useMemo(() => flattenVisibleNodes(tree, collapsedIds), [tree, collapsedIds]);
@@ -99,6 +114,32 @@ export function TaskList({ tasks, onRowClick, onAddChildClick, onDeleteClick, on
                 onCycle={onStatusCycle ? () => onStatusCycle(task) : undefined}
               />
               <Text fontSize="sm" minW="12" textAlign="right">{task.progress}%</Text>
+              {(() => {
+                const overdue = isOverdue(task.dueDate, task.status, now);
+                return (
+                  <Flex
+                    gap={1}
+                    align="center"
+                    minW="36"
+                    justify="flex-end"
+                    data-overdue={String(overdue)}
+                  >
+                    <Text
+                      data-testid="task-date-range"
+                      fontSize="sm"
+                      color={overdue ? 'red.500' : 'fg.muted'}
+                      whiteSpace="nowrap"
+                    >
+                      {formatDateRange(task.startDate, task.dueDate)}
+                    </Text>
+                    {overdue && (
+                      <Badge colorPalette="red" variant="subtle" fontSize="xs">
+                        지남
+                      </Badge>
+                    )}
+                  </Flex>
+                );
+              })()}
               {onAddChildClick && (
                 <Button
                   size="xs"

--- a/lib/overdue/__tests__/is-overdue.test.ts
+++ b/lib/overdue/__tests__/is-overdue.test.ts
@@ -1,0 +1,34 @@
+/**
+ * RED: isOverdue (Issue #11 Stage 1, SPEC §8 H-1 · H-3).
+ */
+import { describe, it, expect } from 'vitest';
+import { isOverdue } from '@/lib/overdue/is-overdue';
+
+describe('isOverdue (SPEC §8 H-1 · H-3)', () => {
+  const today = new Date('2026-05-14T00:00:00Z');
+
+  it('dueDate = null → false', () => {
+    expect(isOverdue(null, 'todo', today)).toBe(false);
+  });
+
+  it('dueDate 가 미래 → false (status 무관)', () => {
+    expect(isOverdue('2026-05-20', 'todo', today)).toBe(false);
+    expect(isOverdue('2026-05-20', 'doing', today)).toBe(false);
+  });
+
+  it('dueDate 가 과거 + status=todo → true', () => {
+    expect(isOverdue('2026-05-10', 'todo', today)).toBe(true);
+  });
+
+  it('dueDate 가 과거 + status=doing → true', () => {
+    expect(isOverdue('2026-05-10', 'doing', today)).toBe(true);
+  });
+
+  it('dueDate 가 과거 + status=done → false (H-3 완료는 경고 해제)', () => {
+    expect(isOverdue('2026-05-10', 'done', today)).toBe(false);
+  });
+
+  it('dueDate === today → false (당일은 아직 overdue 아님)', () => {
+    expect(isOverdue('2026-05-14', 'todo', today)).toBe(false);
+  });
+});

--- a/lib/overdue/is-overdue.ts
+++ b/lib/overdue/is-overdue.ts
@@ -1,0 +1,8 @@
+export function isOverdue(
+  _dueDate: string | null,
+  _status: string,
+  _now: Date = new Date(),
+): boolean {
+  // RED 스텁 — GREEN 단계에서 실제 판정으로 교체.
+  throw new Error('not implemented');
+}

--- a/lib/overdue/is-overdue.ts
+++ b/lib/overdue/is-overdue.ts
@@ -1,8 +1,25 @@
+// SPEC §8 H-1: today > due_date AND status != 'done' → overdue.
+// H-3 완료는 경고 즉시 해제 — done 이면 항상 false.
+// 당일 경계: today === due_date 는 아직 overdue 아님 (마감 당일 여유 해석).
+
+function parseIsoDateUtc(s: string): Date {
+  return new Date(`${s}T00:00:00Z`);
+}
+
+function startOfDayUtc(d: Date): Date {
+  const clone = new Date(d);
+  clone.setUTCHours(0, 0, 0, 0);
+  return clone;
+}
+
 export function isOverdue(
-  _dueDate: string | null,
-  _status: string,
-  _now: Date = new Date(),
+  dueDate: string | null,
+  status: string,
+  now: Date = new Date(),
 ): boolean {
-  // RED 스텁 — GREEN 단계에서 실제 판정으로 교체.
-  throw new Error('not implemented');
+  if (!dueDate) return false;
+  if (status === 'done') return false;
+  const today = startOfDayUtc(now);
+  const due = parseIsoDateUtc(dueDate);
+  return today.getTime() > due.getTime();
 }


### PR DESCRIPTION
## Summary
- SPEC.md §8 H-1·H-2·H-3 근거로 overdue 시각 표시 구현
- **TDD 3단계 + Playwright 스모크** — 각 단계가 RED → GREEN 커밋 쌍
- 목록 뷰에 **기간 컬럼** 도 함께 추가 (SPEC §1 A-2 의 누락 보완)
- 판정 로직은 순수 함수로 분리 · UI 는 `data-overdue` 속성 + Chakra 스타일

## 단계별 진행

| 단계 | 결과 |
|---|---|
| 1. `isOverdue` 순수 함수 | 유닛 6 |
| 2. TaskList 기간 컬럼 + overdue | 유닛 7 |
| 3. GanttBar overdue 테두리 + GanttView 배선 | 유닛 3 |
| 4. Playwright 스모크 | MCP ✓ |

**전체**: 유닛 133 · 통합 42 passed · tsc · lint 깨끗

## 아키텍처 결정
- 판정 로직은 **순수 함수** (`lib/overdue/is-overdue.ts`) · UI 독립 · 유닛 풀커버
- `now` 인자 DI (기본 `new Date()`) · UTC midnight 파싱 · strict `>` (당일 경계 허용)
- 목록 뷰: 기간 셀 "M/D ~ M/D" + overdue 시 `color=red.500` + `<Badge>지남</Badge>`
- 간트 뷰: `GanttBar.overdue` prop → `borderWidth=2px` + `borderColor=red.500` + `data-overdue`
- 판정 위치: 컴포넌트 내부 · DB 에 저장하지 않음 (derived · 시간 따라 자동 갱신)

## Test plan
- [x] 유닛 `npm test` — 133 passed
- [x] 통합 `npm run test:integration` — 42 passed
- [x] `npx tsc --noEmit` / `npm run lint` 깨끗
- [x] Playwright MCP 스모크:
  - [x] 과거 마감(4/10~4/20, doing) → 목록 기간 빨강 + "지남" 배지 (오늘 2026-04-25)
  - [x] 상태 배지 "진행 중" → "완료" 클릭 → "지남" **즉시 사라짐** (H-3)
  - [x] "완료" → "할 일" 재순환 → "지남" 재등장 (판정 동적성 확인)
  - [x] 간트 뷰 전환 → "과거 마감" 막대 빨간 테두리 · "미래 마감" 막대 일반
  - [x] 오늘 세로선 4/25 정상 위치

## 범위 밖 (후속 polish)
- Overdue 필터/정렬 · 알림 · 빗금 오버레이 · 로케일 포맷 · 상대 시간 표시

Closes #11

🤖 Generated with [Claude Code](https://claude.com/claude-code)