### PR TITLE
chore: #17 lib/db lazy connection 리팩터 + CI 더미 env 제거

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,10 +37,4 @@ jobs:
         run: npm test
 
       - name: Build
-        env:
-          # Next 14 가 "collecting page data" 단계에서 페이지 모듈을 import 하면서
-          # lib/db/index.ts 의 top-level throw 가 발동해 빌드가 깨짐.
-          # 이 단계에서 실제 쿼리는 돌지 않으므로 더미 URL 로 충분.
-          # 근본 해결(lazy db connection) 은 별도 chore 이슈에서 진행.
-          DATABASE_URL: postgresql://postgres:postgres@localhost:5432/postgres
         run: npm run build

--- a/lib/db/__tests__/lazy.test.ts
+++ b/lib/db/__tests__/lazy.test.ts
@@ -1,0 +1,54 @@
+/**
+ * RED: lib/db lazy connection (Issue #17 Stage 1).
+ *
+ * 모듈 import 만으로는 DATABASE_URL 체크 안 함.
+ * 실제 쿼리(= db 객체의 property 접근) 시점에만 검증 + 연결.
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+
+const ORIG_DATABASE_URL = process.env.DATABASE_URL;
+
+describe('lib/db lazy connection', () => {
+  beforeEach(() => {
+    vi.resetModules();
+  });
+
+  afterEach(() => {
+    if (ORIG_DATABASE_URL !== undefined) {
+      process.env.DATABASE_URL = ORIG_DATABASE_URL;
+    } else {
+      delete process.env.DATABASE_URL;
+    }
+  });
+
+  it('DATABASE_URL 없이 모듈 import → throw 하지 않음', async () => {
+    delete process.env.DATABASE_URL;
+    await expect(import('@/lib/db')).resolves.toBeDefined();
+  });
+
+  it('db 는 import 후 정의되어 있음 (Proxy 객체)', async () => {
+    delete process.env.DATABASE_URL;
+    const mod = await import('@/lib/db');
+    expect(mod.db).toBeDefined();
+    expect(typeof mod.db).toBe('object');
+  });
+
+  it('DATABASE_URL 없이 db property 접근 → DATABASE_URL 관련 throw', async () => {
+    delete process.env.DATABASE_URL;
+    const { db } = await import('@/lib/db');
+    expect(() => {
+      // property get 이 lazy 로 내부 초기화 트리거
+      const _ = (db as unknown as { select: unknown }).select;
+      void _;
+    }).toThrow(/DATABASE_URL/);
+  });
+
+  it('DATABASE_URL 있을 때 db property 접근 → throw 하지 않음', async () => {
+    process.env.DATABASE_URL = 'postgresql://u:p@localhost:5432/test';
+    const { db } = await import('@/lib/db');
+    expect(() => {
+      const _ = (db as unknown as { select: unknown }).select;
+      void _;
+    }).not.toThrow();
+  });
+});

--- a/lib/db/index.ts
+++ b/lib/db/index.ts
@@ -2,12 +2,32 @@ import { drizzle } from 'drizzle-orm/postgres-js';
 import postgres from 'postgres';
 import * as schema from './schema';
 
-const connectionString = process.env.DATABASE_URL;
+// Lazy connection — 모듈 import 만으로는 DATABASE_URL 을 읽지 않는다.
+// Next 14 의 "collecting page data" 같은 import 전파 단계에서 top-level throw
+// 가 빌드를 깨는 것을 방지 (Issue #17).
 
-if (!connectionString) {
-  throw new Error('DATABASE_URL 이 설정되지 않았습니다. `.env.local` 을 확인하세요.');
+type DrizzleClient = ReturnType<typeof drizzle<typeof schema>>;
+
+let cached: DrizzleClient | undefined;
+
+function getDb(): DrizzleClient {
+  if (cached) return cached;
+  const url = process.env.DATABASE_URL;
+  if (!url) {
+    throw new Error('DATABASE_URL 이 설정되지 않았습니다. `.env.local` 을 확인하세요.');
+  }
+  const client = postgres(url, { prepare: false });
+  cached = drizzle(client, { schema });
+  return cached;
 }
 
-const client = postgres(connectionString, { prepare: false });
-
-export const db = drizzle(client, { schema });
+// Proxy 를 통해 호출처(`import { db }`) 를 유지하면서도 실제 초기화는
+// property 접근 시점까지 지연. 함수는 bind 해서 Drizzle builder chain 의
+// this 컨텍스트 보존.
+export const db = new Proxy({} as DrizzleClient, {
+  get(_target, prop) {
+    const actual = getDb();
+    const value = (actual as unknown as Record<string | symbol, unknown>)[prop];
+    return typeof value === 'function' ? (value as (...args: unknown[]) => unknown).bind(actual) : value;
+  },
+});


### PR DESCRIPTION
## Summary
- `lib/db/index.ts` 를 Proxy 기반 lazy connection 으로 리팩터
- 모듈 import 만으로는 `DATABASE_URL` 검증하지 않음 — 실제 쿼리 시점에만 검증·연결
- `.github/workflows/ci.yml` build 스텝의 더미 `DATABASE_URL` env + 설명 주석 제거
- 외부 API (`import { db }`) 불변 — 호출처(`app/actions/*`, `app/page.tsx` 등) 수정 0

## 배경 (Why)
PR #16 머지 시점 CI 의 `npm run build` "collecting page data" 단계에서 `lib/db` 의 top-level throw 로 빌드가 깨졌음 (`49ea7a7` 에서 더미 `DATABASE_URL` 로 임시 우회). 이 PR 이 근본 해결.

## 구현 (Proxy pattern)
```ts
type DrizzleClient = ReturnType<typeof drizzle<typeof schema>>;
let cached: DrizzleClient | undefined;

function getDb(): DrizzleClient {
  if (cached) return cached;
  const url = process.env.DATABASE_URL;
  if (!url) throw new Error('DATABASE_URL 이 설정되지 않았습니다. …');
  const client = postgres(url, { prepare: false });
  cached = drizzle(client, { schema });
  return cached;
}

export const db = new Proxy({} as DrizzleClient, {
  get(_target, prop) {
    const actual = getDb();
    const value = (actual as unknown as Record<string | symbol, unknown>)[prop];
    return typeof value === 'function'
      ? (value as (...args: unknown[]) => unknown).bind(actual)
      : value;
  },
});
```
- 모듈 레벨 `cached` 싱글턴 — postgres-js pool 재생성 방지
- Proxy.get 에서 함수는 `value.bind(actual)` — Drizzle builder chain 의 `this` 보존

## 단계별 진행
| Stage | 커밋 |
|---|---|
| 1. lazy db Proxy + 테스트 | `88d4136` (RED 3+1) → `faf88ac` (GREEN 4) |
| 2. CI 더미 env 제거 | `ea48d6a` |
| 3. 수동 검증 | 코드 변경 없음 — Playwright MCP 통과 |

## Test plan
- [x] 유닛 137 passed (기존 133 + lazy 4)
- [x] 통합 42 passed (Proxy 를 실제 호출해 DB 조작 — `app/actions/*` 전부 통과)
- [x] `npx tsc --noEmit` / `npm run lint` 깨끗
- [x] 로컬 `env -u DATABASE_URL npm run build` 성공
- [x] `npm run dev` + Playwright MCP 홈 진입 → 기존 tasks 정상 렌더 (Proxy delegate 증명)
- [ ] PR Actions check 초록 (CI 의 더미 env 없이도 build 통과 확인)

## 변경 파일
- `lib/db/index.ts` — Proxy lazy 패턴 (29 lines)
- `lib/db/__tests__/lazy.test.ts` — 4 tests (신규)
- `.github/workflows/ci.yml` — 6 lines 삭제 (env 블록 + 주석)

Closes #17

🤖 Generated with [Claude Code](https://claude.com/claude-code)