### PR TITLE
fix: #27 목록·간트 정렬 — 토글 슬롯 + depth 2+ 들여쓰기

### DIFF
--- a/components/__tests__/gantt-view.test.tsx
+++ b/components/__tests__/gantt-view.test.tsx
@@ -100,4 +100,30 @@ describe('<GanttView />', () => {
     expect(depths).toContain('0');
     expect(depths).toContain('1');
   });
+
+  it('depth 별 들여쓰기가 16px 일관 증분 (#27 — 2depth+ Chakra spacing fallback 버그)', () => {
+    const a = makeTask({ id: 'a', title: 'A' });
+    const b = makeTask({
+      id: 'b',
+      title: 'B',
+      parentId: 'a',
+      createdAt: new Date('2026-04-02T00:00:00Z'),
+    });
+    const c = makeTask({
+      id: 'c',
+      title: 'C',
+      parentId: 'b',
+      createdAt: new Date('2026-04-03T00:00:00Z'),
+    });
+    const d = makeTask({
+      id: 'd',
+      title: 'D',
+      parentId: 'c',
+      createdAt: new Date('2026-04-04T00:00:00Z'),
+    });
+    const { container } = renderWithChakra(<GanttView tasks={[a, b, c, d]} />);
+    const rows = container.querySelectorAll('[data-depth]');
+    const indentPxs = Array.from(rows).map((r) => Number(r.getAttribute('data-indent-px')));
+    expect(indentPxs).toEqual([12, 28, 44, 60]);
+  });
 });

--- a/components/__tests__/task-list.test.tsx
+++ b/components/__tests__/task-list.test.tsx
@@ -270,6 +270,29 @@ describe('<TaskList />', () => {
       expect(onRowClick).not.toHaveBeenCalled();
     });
 
+    it('하위작업 유무와 무관하게 toggle 슬롯이 동일한 너비로 렌더 (#27)', () => {
+      const p = makeTask({ id: 'p', title: 'Parent' });
+      const c = makeTask({
+        id: 'c',
+        title: 'Child',
+        parentId: 'p',
+        createdAt: new Date('2026-04-02T00:00:00Z'),
+      });
+      const solo = makeTask({
+        id: 's',
+        title: 'Solo',
+        createdAt: new Date('2026-04-03T00:00:00Z'),
+      });
+      const { container } = renderWithChakra(
+        <TaskList tasks={[p, c, solo]} onRowClick={vi.fn()} />,
+      );
+      const slots = container.querySelectorAll('[data-testid="task-toggle-slot"]');
+      expect(slots).toHaveLength(3);
+      const widths = Array.from(slots).map((s) => s.getAttribute('data-slot-width'));
+      expect(widths[0]).toBeTruthy();
+      expect(new Set(widths).size).toBe(1);
+    });
+
     it('조부 접으면 자식과 손자 모두 사라짐', () => {
       const p = makeTask({ id: 'p', title: 'Parent' });
       const c = makeTask({ id: 'c', parentId: 'p', title: 'Child' });

--- a/components/__tests__/task-list.test.tsx
+++ b/components/__tests__/task-list.test.tsx
@@ -270,6 +270,36 @@ describe('<TaskList />', () => {
       expect(onRowClick).not.toHaveBeenCalled();
     });
 
+    it('depth 별 들여쓰기가 24px 일관 증분 (#27 — 2depth+ Chakra spacing fallback 버그)', () => {
+      const a = makeTask({ id: 'a', title: 'A' });
+      const b = makeTask({
+        id: 'b',
+        title: 'B',
+        parentId: 'a',
+        createdAt: new Date('2026-04-02T00:00:00Z'),
+      });
+      const c = makeTask({
+        id: 'c',
+        title: 'C',
+        parentId: 'b',
+        createdAt: new Date('2026-04-03T00:00:00Z'),
+      });
+      const d = makeTask({
+        id: 'd',
+        title: 'D',
+        parentId: 'c',
+        createdAt: new Date('2026-04-04T00:00:00Z'),
+      });
+      const { container } = renderWithChakra(
+        <TaskList tasks={[a, b, c, d]} onRowClick={vi.fn()} />,
+      );
+      const rows = container.querySelectorAll('[data-depth]');
+      const indentPxs = Array.from(rows).map((r) =>
+        Number(r.getAttribute('data-indent-px')),
+      );
+      expect(indentPxs).toEqual([12, 36, 60, 84]);
+    });
+
     it('하위작업 유무와 무관하게 toggle 슬롯이 동일한 너비로 렌더 (#27)', () => {
       const p = makeTask({ id: 'p', title: 'Parent' });
       const c = makeTask({

--- a/components/gantt-view.tsx
+++ b/components/gantt-view.tsx
@@ -57,16 +57,21 @@ export function GanttView({ tasks, now = new Date() }: GanttViewProps) {
       <Box width={LEFT_COL_WIDTH} flexShrink={0} borderRightWidth="1px">
         {/* 헤더 높이 맞춤 */}
         <Box h={ROW_HEIGHT} borderBottomWidth="1px" />
-        {flat.map((node) => (
+        {flat.map((node) => {
+          // task-list 와 동일한 Chakra v3 spacing fallback 회피.
+          // 좌측 컬럼 240px 안에서 16px 증분 (depth 0→12, 1→28, 2→44, 3→60).
+          const indentPx = 12 + node.depth * 16;
+          return (
           <Flex
             key={node.task.id}
             h={ROW_HEIGHT}
             alignItems="center"
-            pl={3 + node.depth * 4}
+            pl={`${indentPx}px`}
             pr={2}
             borderBottomWidth="1px"
             gap={2}
             data-depth={node.depth}
+            data-indent-px={String(indentPx)}
           >
             <Text fontSize="sm" fontWeight="medium" flex="1" truncate>
               {node.task.title}
@@ -75,7 +80,8 @@ export function GanttView({ tasks, now = new Date() }: GanttViewProps) {
               {node.task.progress}%
             </Text>
           </Flex>
-        ))}
+          );
+        })}
       </Box>
 
       {/* 우측: 날짜 그리드 + 막대 + 오늘선 */}

--- a/components/task-list.tsx
+++ b/components/task-list.tsx
@@ -70,6 +70,9 @@ export function TaskList({ tasks, onRowClick, onAddChildClick, onDeleteClick, on
         const { task, depth, children } = node;
         const hasChildren = children.length > 0;
         const isCollapsed = collapsedIds.has(task.id);
+        // Chakra v3 spacing scale 은 12,14,16... 으로 점프 — 임의 정수(15,21)는
+        // 토큰 미스로 raw px fallback 됨. 직접 px 단위로 계산해 일관 증분 보장.
+        const indentPx = 12 + depth * 24;
         return (
           <Box
             key={task.id}
@@ -77,6 +80,7 @@ export function TaskList({ tasks, onRowClick, onAddChildClick, onDeleteClick, on
             aria-label={`작업: ${task.title}`}
             tabIndex={0}
             data-depth={depth}
+            data-indent-px={String(indentPx)}
             onClick={() => onRowClick(task)}
             onKeyDown={(e) => {
               if (e.key === 'Enter' || e.key === ' ') {
@@ -86,7 +90,7 @@ export function TaskList({ tasks, onRowClick, onAddChildClick, onDeleteClick, on
             }}
             cursor="pointer"
             p={3}
-            pl={3 + depth * 6}
+            pl={`${indentPx}px`}
             borderWidth="1px"
             borderRadius="md"
             _hover={{ bg: 'bg.subtle' }}

--- a/components/task-list.tsx
+++ b/components/task-list.tsx
@@ -92,11 +92,21 @@ export function TaskList({ tasks, onRowClick, onAddChildClick, onDeleteClick, on
             _hover={{ bg: 'bg.subtle' }}
           >
             <Flex gap={4} align="center">
-              <Box minW={4}>
+              <Box
+                w={7}
+                flexShrink={0}
+                display="flex"
+                alignItems="center"
+                justifyContent="center"
+                data-testid="task-toggle-slot"
+                data-slot-width="28"
+              >
                 {hasChildren && (
                   <Button
                     size="xs"
                     variant="ghost"
+                    minW={0}
+                    px={1}
                     aria-label={isCollapsed ? '펼치기' : '접기'}
                     onClick={(e) => {
                       e.stopPropagation();


### PR DESCRIPTION
## Summary
목록·간트 행 정렬 세 가지 버그 동시 수정.

1. **토글 슬롯 너비 불일치 (목록)** — 자식 유무에 따라 슬롯이 16px / 28px 로 달라져 같은 depth 끼리도 제목이 12px 어긋남.
2. **depth 2+ 들여쓰기 깨짐 (목록)** — `pl={3 + depth * 6}` 이 Chakra spacing 토큰 미정의(15, 21) → raw px fallback. depth 2 가 60px 가 아닌 15px.
3. **depth 2+ 들여쓰기 깨짐 (간트)** — `pl={3 + depth * 4}` 동일 패턴. depth 2 가 44px 가 아닌 11px.

## Before / After

### Bug 1 — 목록 토글 슬롯
| 항목 | Before | After |
|---|---|---|
| 자식 없는 행 슬롯 | 16px (`minW={4}`) | 28px (`w={7}`) |
| 자식 있는 행 슬롯 | ~28px (Button 자연 너비) | 28px (`minW={0} px={1}`) |

### Bug 2 — 목록 depth 들여쓰기 (24px 증분)
| depth | Before | After |
|---|---|---|
| 0 | 12px | 12px |
| 1 | 36px | 36px |
| 2 | **15px** ❌ | **60px** ✅ |
| 3 | **21px** ❌ | **84px** ✅ |

### Bug 3 — 간트 좌측 트리 들여쓰기 (16px 증분, 240px 컬럼)
| depth | Before | After |
|---|---|---|
| 0 | 12px | 12px |
| 1 | 28px | 28px |
| 2 | **11px** ❌ | **44px** ✅ |
| 3 | **15px** ❌ | **60px** ✅ |

공통 원인: Chakra v3 spacing scale 은 …,12,14,16,20,24,… 점프 → 임의 정수는 토큰 미스 → raw px fallback.

## 변경

`components/task-list.tsx`:
- 토글 wrapper Box → `w={7} flexShrink={0}` + `data-testid="task-toggle-slot"` + `data-slot-width="28"`
- Button → `minW={0} px={1}`
- 들여쓰기 계산식을 `indentPx = 12 + depth * 24` 로 바꾸고 px 문자열로 직접 전달, `data-indent-px` 회귀 가드

`components/gantt-view.tsx`:
- 들여쓰기 계산식을 `indentPx = 12 + depth * 16` 로 바꾸고 px 문자열로 직접 전달, `data-indent-px` 회귀 가드
- (좌측 컬럼 폭 240px 고려해 16px 증분 유지)

테스트:
- `task-list.test.tsx` — RED 2건 (토글 슬롯 일관 너비 + depth 일관 증분)
- `gantt-view.test.tsx` — RED 1건 (depth 일관 증분)

## Test plan
- [x] RED 3건 → GREEN 통과
- [x] 기존 task-list/gantt-view 테스트 회귀 없음
- [x] 유닛 143 / 통합 42 / tsc / lint 깨끗
- [x] Playwright 시각 검증 — 목록 depth 0~3 + 토글 슬롯 일관 (`toggle-slot-aligned.png`)

## 영향 범위
- 키보드 포커스 흐름: 변동 없음
- ARIA 레이블: 변동 없음
- 들여쓰기 형태: 의도된 24px(목록) / 16px(간트) 증분으로 **정상화**

Closes #27

🤖 Generated with [Claude Code](https://claude.com/claude-code)
