### PR TITLE
fix: #29 간트 '일정 없음' 텍스트 수직 중앙 정렬

### DIFF
--- a/components/__tests__/gantt-bar.test.tsx
+++ b/components/__tests__/gantt-bar.test.tsx
@@ -121,4 +121,15 @@ describe('<GanttBar />', () => {
       expect(container.querySelector('[data-overdue]')).toBeNull();
     });
   });
+
+  describe('"일정 없음" 수직 정렬 (#29)', () => {
+    it('빈 상태 wrapper 가 data-testid="gantt-empty" 로 렌더되고 텍스트 포함', () => {
+      const { container } = renderWithChakra(
+        <GanttBar startDate={null} dueDate={null} progress={0} range={range} />,
+      );
+      const empty = container.querySelector('[data-testid="gantt-empty"]');
+      expect(empty).not.toBeNull();
+      expect(empty?.textContent).toMatch(/일정 없음/);
+    });
+  });
 });

--- a/components/gantt-bar.tsx
+++ b/components/gantt-bar.tsx
@@ -15,9 +15,18 @@ export function GanttBar({ startDate, dueDate, progress, range, overdue = false 
   // SPEC §7 G-2: 시작일/목표 기한 중 하나라도 비면 막대 없이 "— 일정 없음 —" 표기.
   if (!startDate || !dueDate) {
     return (
-      <Text fontSize="sm" color="fg.muted" textAlign="center">
-        — 일정 없음 —
-      </Text>
+      <Box
+        position="absolute"
+        inset="0"
+        display="flex"
+        alignItems="center"
+        justifyContent="center"
+        data-testid="gantt-empty"
+      >
+        <Text fontSize="sm" color="fg.muted">
+          — 일정 없음 —
+        </Text>
+      </Box>
     );
   }
 


### PR DESCRIPTION
## Summary
간트에서 시작일·기한이 비어 있는 행의 "— 일정 없음 —" 텍스트가 행 상단에 붙어 출력되던 문제 수정. 막대와 동일하게 행 수직 중앙으로 정렬.

## Before / After
| 항목 | Before | After |
|---|---|---|
| 빈 상태 텍스트 배치 | 흐름 배치 (행 상단에 붙음) | absolute inset=0 + flex center (수직 중앙) |
| 막대(`GanttBar`) 와의 정렬 | 어긋남 | 동일 (둘 다 행 중앙) |

## 변경
- `components/gantt-bar.tsx` 빈 상태 분기:
  - `<Text textAlign="center">` 만 → `<Box absolute inset=0 flex center>` wrapper 로 감싸고 안에 `<Text>` 배치
  - `data-testid="gantt-empty"` 회귀 가드
- `components/__tests__/gantt-bar.test.tsx` — RED 1건 (`data-testid="gantt-empty"` 존재 + 텍스트 포함)

## Test plan
- [x] RED 1건 → GREEN 통과 (gantt-bar 9 → 10건)
- [x] 기존 gantt-bar/view 테스트 회귀 없음
- [x] 유닛 141 / 통합 42 / tsc / lint 깨끗
- [x] Playwright 시각 검증 — 시작일·기한 비어 있는 행 2건 모두 wrapper 가 `position:absolute · inset:0 · flex center` 로 렌더되고, 텍스트 중심 y = 행 중심 y = 18px (행 높이 36px) 일치. 스크린샷 `gantt-empty-vcenter.png` 첨부.

## 검증 측정값
| 항목 | 값 |
|---|---|
| wrapper position | `absolute` |
| wrapper inset | `top/right/bottom/left = 0` |
| wrapper display / align / justify | `flex / center / center` |
| 행 높이 | 36px |
| 텍스트 중심 y (행 기준) | 18px |
| 행 중심 y | 18px |

## 영향 범위
- 막대 분기 정렬: 변동 없음 (이미 중앙)
- ARIA / 키보드: 변동 없음
- 빈 상태 텍스트 자체(문구·색): 변동 없음

Closes #29

🤖 Generated with [Claude Code](https://claude.com/claude-code)
