### PR TITLE
feat: #33 상단 액션 순서 + 목록 컬럼 헤더 행 (SPEC §1 A-4)

### DIFF
--- a/components/__tests__/task-list.test.tsx
+++ b/components/__tests__/task-list.test.tsx
@@ -13,6 +13,23 @@ describe('<TaskList />', () => {
     expect(screen.getByText(/아직 작업이 없습니다/)).toBeInTheDocument();
   });
 
+  it('tasks=[] → 컬럼 헤더 행도 표시되지 않음 (#33)', () => {
+    const { container } = renderWithChakra(<TaskList tasks={[]} onRowClick={vi.fn()} />);
+    expect(container.querySelector('[data-testid="task-list-header"]')).toBeNull();
+  });
+
+  it('tasks 가 있으면 컬럼 헤더 행 표시 — 제목/담당자/상태/진행률/기간 라벨 모두 포함 (#33 SPEC §1 A-4)', () => {
+    const t = makeTask({ id: 'a', title: 'X' });
+    const { container } = renderWithChakra(<TaskList tasks={[t]} onRowClick={vi.fn()} />);
+    const header = container.querySelector('[data-testid="task-list-header"]');
+    expect(header).not.toBeNull();
+    expect(header?.textContent).toContain('제목');
+    expect(header?.textContent).toContain('담당자');
+    expect(header?.textContent).toContain('상태');
+    expect(header?.textContent).toContain('진행률');
+    expect(header?.textContent).toContain('기간');
+  });
+
   it('tasks 가 있으면 각 행이 role=button 으로 클릭 가능', () => {
     const t1 = makeTask({ id: 'id-1', title: 'Alpha' });
     const t2 = makeTask({ id: 'id-2', title: 'Beta' });

--- a/components/__tests__/tasks-page-client.test.tsx
+++ b/components/__tests__/tasks-page-client.test.tsx
@@ -81,4 +81,13 @@ describe('<TasksPageClient /> 뷰 토글 (Stage 4)', () => {
     expect(screen.getByRole('button', { name: 'CSV 내보내기' })).toBeInTheDocument();
     expect(screen.getByRole('button', { name: 'CSV 불러오기' })).toBeInTheDocument();
   });
+
+  it('상단 버튼 순서: 목록 → 간트 → + 작업 추가 → CSV 내보내기 → CSV 불러오기 (#33 SPEC §1 A-4)', () => {
+    const { container } = renderWithChakra(<TasksPageClient initialTasks={[]} />);
+    const labels = ['목록', '간트', '+ 작업 추가', 'CSV 내보내기', 'CSV 불러오기'];
+    const buttons = Array.from(container.querySelectorAll('button')).filter((b) =>
+      labels.includes(b.textContent?.trim() ?? ''),
+    );
+    expect(buttons.map((b) => b.textContent?.trim())).toEqual(labels);
+  });
 });

--- a/components/task-list.tsx
+++ b/components/task-list.tsx
@@ -77,6 +77,7 @@ export function TaskList({ tasks, onRowClick, onAddChildClick, onDeleteClick, on
         data-testid="task-list-header"
         p={3}
         pl="12px"
+        borderTopWidth="1px"
         borderBottomWidth="1px"
         color="fg.muted"
         fontWeight="medium"

--- a/components/task-list.tsx
+++ b/components/task-list.tsx
@@ -72,6 +72,25 @@ export function TaskList({ tasks, onRowClick, onAddChildClick, onDeleteClick, on
 
   return (
     <Stack gap={2}>
+      {/* 컬럼 헤더 (SPEC §1 A-4) — 작업 행과 동일 컬럼 폭 */}
+      <Box
+        data-testid="task-list-header"
+        p={3}
+        pl="12px"
+        borderBottomWidth="1px"
+        color="fg.muted"
+        fontWeight="medium"
+        fontSize="sm"
+      >
+        <Flex gap={4} align="center">
+          <Box w={7} flexShrink={0} />
+          <Text flex="1">제목</Text>
+          <Text minW="20">담당자</Text>
+          <Text minW="16" textAlign="center">상태</Text>
+          <Text minW="12" textAlign="right">진행률</Text>
+          <Text minW="36" textAlign="right">기간</Text>
+        </Flex>
+      </Box>
       {visibleNodes.map((node) => {
         const { task, depth, children } = node;
         const hasChildren = children.length > 0;

--- a/components/task-list.tsx
+++ b/components/task-list.tsx
@@ -72,7 +72,7 @@ export function TaskList({ tasks, onRowClick, onAddChildClick, onDeleteClick, on
 
   return (
     <Stack gap={2}>
-      {/* 컬럼 헤더 (SPEC §1 A-4) — 작업 행과 동일 컬럼 폭 */}
+      {/* 컬럼 헤더 (SPEC §1 A-4) — 작업 행과 동일 컬럼 폭/구조 */}
       <Box
         data-testid="task-list-header"
         p={3}
@@ -87,9 +87,24 @@ export function TaskList({ tasks, onRowClick, onAddChildClick, onDeleteClick, on
           <Box w={7} flexShrink={0} />
           <Text flex="1">제목</Text>
           <Text minW="20">담당자</Text>
-          <Text minW="16" textAlign="center">상태</Text>
+          <Box minW="20" display="flex" justifyContent="center">
+            <Text>상태</Text>
+          </Box>
           <Text minW="12" textAlign="right">진행률</Text>
-          <Text minW="36" textAlign="right">기간</Text>
+          <Flex minW="36" justify="flex-end">
+            <Text>기간</Text>
+          </Flex>
+          {/* 행의 + 하위 / 삭제 버튼 자리 — 헤더는 같은 폭만 차지하고 시각적 비표시 */}
+          {onAddChildClick && (
+            <Button size="xs" variant="ghost" visibility="hidden" aria-hidden tabIndex={-1}>
+              + 하위
+            </Button>
+          )}
+          {onDeleteClick && (
+            <Button size="xs" variant="ghost" visibility="hidden" aria-hidden tabIndex={-1}>
+              삭제
+            </Button>
+          )}
         </Flex>
       </Box>
       {visibleNodes.map((node) => {
@@ -149,10 +164,12 @@ export function TaskList({ tasks, onRowClick, onAddChildClick, onDeleteClick, on
               </Box>
               <Text flex="1" fontWeight="medium">{task.title}</Text>
               <Text color="fg.muted" minW="20">{task.assignee ?? '—'}</Text>
-              <StatusBadge
-                status={task.status as TaskStatus}
-                onCycle={onStatusCycle ? () => onStatusCycle(task) : undefined}
-              />
+              <Box minW="20" display="flex" justifyContent="center">
+                <StatusBadge
+                  status={task.status as TaskStatus}
+                  onCycle={onStatusCycle ? () => onStatusCycle(task) : undefined}
+                />
+              </Box>
               <Text fontSize="sm" minW="12" textAlign="right">{task.progress}%</Text>
               {(() => {
                 const overdue = isOverdue(task.dueDate, task.status, now);

--- a/components/tasks-page-client.tsx
+++ b/components/tasks-page-client.tsx
@@ -100,10 +100,10 @@ export function TasksPageClient({ initialTasks }: { initialTasks: Task[] }) {
               간트
             </Button>
           </Flex>
-          <CsvToolbar existingTasks={initialTasks} />
           <Button onClick={() => setModal({ kind: 'create', parentId: null })}>
             + 작업 추가
           </Button>
+          <CsvToolbar existingTasks={initialTasks} />
         </Flex>
       </Flex>
 


### PR DESCRIPTION
## Summary
SPEC §1 A-4 화면 목업과 어긋나던 두 가지 정렬:

1. **상단 액션 버튼 순서** — `+ 작업 추가` 를 CSV 버튼 앞으로 이동
2. **목록 컬럼 헤더 행 추가** — 제목/담당자/상태/진행률/기간 라벨

## Before / After

### 상단 버튼 순서
| | Before | After |
|---|---|---|
| 우측 그룹 | `[목록\|간트] [CSV 내보내기][CSV 불러오기] [+ 작업 추가]` | `[목록\|간트] [+ 작업 추가] [CSV 내보내기][CSV 불러오기]` |

### 목록 컬럼 헤더
| | Before | After |
|---|---|---|
| 헤더 행 | 없음 — 행만 곧장 노출 | `제목 / 담당자 / 상태 / 진행률 / 기간` 라벨 행 |

## 변경

`components/tasks-page-client.tsx`
- `<Button>+ 작업 추가</Button>` 를 `<CsvToolbar />` 앞으로 이동

`components/task-list.tsx`
- `<Stack>` 위에 `<Box data-testid="task-list-header">` 헤더 추가
- 작업 행과 동일한 컬럼 폭 (`w={7}` 토글 / `flex="1"` 제목 / `minW="20"` 담당자 / `minW="16"` 상태 / `minW="12"` 진행률 / `minW="36"` 기간)
- `borderBottomWidth="1px"`, `color="fg.muted"`, `fontWeight="medium"`
- 행동 버튼 컬럼(+하위/삭제)은 헤더 라벨 두지 않음 (hover-노출 액션이라 라벨 불필요)
- 빈 상태에서는 헤더 미렌더 (안내 문구만)

## Test plan
- [x] Stage A RED 1 → GREEN: 우측 그룹 버튼 순서 `[목록, 간트, + 작업 추가, CSV 내보내기, CSV 불러오기]`
- [x] Stage B RED 2 → GREEN: 헤더 행 라벨 5개 / 빈 상태에서 헤더 없음
- [x] 유닛 168 / 통합 42 / tsc / lint 깨끗
- [x] Playwright 시각 검증 (`list-header-and-toolbar.png`)

## 영향 범위

- 기존 행 클릭/펼침/접힘 동작: 변동 없음
- 키보드 포커스 흐름: 헤더는 클릭 가능 영역 아님 → Tab 으로 도달 안 함
- ARIA: 헤더는 단순 텍스트 행 (role 미지정)
- 빈 상태: 헤더 없이 기존 안내 문구만 — 회귀 가드 테스트 포함

## 범위 밖

- 헤더 sticky (스크롤해도 상단 고정)
- 정렬/필터 (SPEC §1 A-3 — MVP 범위 밖)
- 모바일 반응형

Closes #33

🤖 Generated with [Claude Code](https://claude.com/claude-code)
