### PR TITLE
feat: #35 간트 행 높이 + 좌측 헤더 라벨 (SPEC §7 G-4)

### DIFF
--- a/components/__tests__/gantt-view.test.tsx
+++ b/components/__tests__/gantt-view.test.tsx
@@ -277,15 +277,15 @@ describe('<GanttView />', () => {
       expect(screen.getByText('진행률')).toBeInTheDocument();
     });
 
-    it("헤더와 작업 행 모두 data-row-height-px=\"52\" (목록 행과 시각적 일치)", () => {
+    it("헤더와 작업 행 모두 data-row-height-px=\"58\" (목록 행과 시각적 일치)", () => {
       const t = makeTask({ id: 'a', title: 'X' });
       const { container } = renderWithChakra(<GanttView tasks={[t]} />);
       const heights = Array.from(container.querySelectorAll('[data-row-height-px]')).map((el) =>
         el.getAttribute('data-row-height-px'),
       );
-      // 좌측 헤더 + 좌측 행 + 우측 헤더 + 우측 행 = 4 elements 모두 "52"
+      // 좌측 헤더 + 좌측 행 + 우측 헤더 + 우측 행 = 4 elements 모두 "58"
       expect(heights.length).toBeGreaterThanOrEqual(4);
-      expect(heights.every((h) => h === '52')).toBe(true);
+      expect(heights.every((h) => h === '58')).toBe(true);
     });
   });
 });

--- a/components/__tests__/gantt-view.test.tsx
+++ b/components/__tests__/gantt-view.test.tsx
@@ -268,4 +268,24 @@ describe('<GanttView />', () => {
       expect(totalDays).toBe(210);
     });
   });
+
+  describe('#35 좌측 컬럼 헤더 + 행 높이', () => {
+    it("좌측 헤더에 '작업' / '진행률' 라벨 (SPEC §7 G-4)", () => {
+      const t = makeTask({ id: 'a', title: 'X' });
+      renderWithChakra(<GanttView tasks={[t]} />);
+      expect(screen.getByText('작업')).toBeInTheDocument();
+      expect(screen.getByText('진행률')).toBeInTheDocument();
+    });
+
+    it("헤더와 작업 행 모두 data-row-height-px=\"52\" (목록 행과 시각적 일치)", () => {
+      const t = makeTask({ id: 'a', title: 'X' });
+      const { container } = renderWithChakra(<GanttView tasks={[t]} />);
+      const heights = Array.from(container.querySelectorAll('[data-row-height-px]')).map((el) =>
+        el.getAttribute('data-row-height-px'),
+      );
+      // 좌측 헤더 + 좌측 행 + 우측 헤더 + 우측 행 = 4 elements 모두 "52"
+      expect(heights.length).toBeGreaterThanOrEqual(4);
+      expect(heights.every((h) => h === '52')).toBe(true);
+    });
+  });
 });

--- a/components/gantt-view.tsx
+++ b/components/gantt-view.tsx
@@ -21,7 +21,8 @@ export type GanttViewProps = {
 };
 
 const LEFT_COL_WIDTH = '240px';
-const ROW_HEIGHT = '36px';
+const ROW_HEIGHT = '52px';
+const ROW_HEIGHT_PX = '52';
 const INITIAL_PAD_DAYS = 90;
 const EDGE_THRESHOLD_PX = 200;
 const EXTEND_DAYS = 60;
@@ -135,7 +136,22 @@ export function GanttView({ tasks, now = new Date() }: GanttViewProps) {
     <Flex borderWidth="1px" borderRadius="md" overflow="hidden">
       {/* 좌측: 작업 트리 */}
       <Box width={LEFT_COL_WIDTH} flexShrink={0} borderRightWidth="1px">
-        <Box h={ROW_HEIGHT} borderBottomWidth="1px" />
+        {/* 좌측 헤더 — SPEC §7 G-4: '작업' / '진행률' */}
+        <Flex
+          h={ROW_HEIGHT}
+          alignItems="center"
+          pl="12px"
+          pr={2}
+          gap={2}
+          borderBottomWidth="1px"
+          color="fg.muted"
+          fontWeight="medium"
+          fontSize="sm"
+          data-row-height-px={ROW_HEIGHT_PX}
+        >
+          <Text flex="1">작업</Text>
+          <Text>진행률</Text>
+        </Flex>
         {flat.map((node) => {
           const indentPx = 12 + node.depth * 16;
           return (
@@ -149,6 +165,7 @@ export function GanttView({ tasks, now = new Date() }: GanttViewProps) {
               gap={2}
               data-depth={node.depth}
               data-indent-px={String(indentPx)}
+              data-row-height-px={ROW_HEIGHT_PX}
             >
               <Text fontSize="sm" fontWeight="medium" flex="1" truncate>
                 {node.task.title}
@@ -207,6 +224,7 @@ export function GanttView({ tasks, now = new Date() }: GanttViewProps) {
             top={0}
             bg="bg"
             zIndex={1}
+            data-row-height-px={ROW_HEIGHT_PX}
           >
             {marks.map((m, i) => (
               <Text
@@ -232,6 +250,7 @@ export function GanttView({ tasks, now = new Date() }: GanttViewProps) {
               h={ROW_HEIGHT}
               borderBottomWidth="1px"
               position="relative"
+              data-row-height-px={ROW_HEIGHT_PX}
             >
               <GanttBar
                 startDate={node.task.startDate}

--- a/components/gantt-view.tsx
+++ b/components/gantt-view.tsx
@@ -21,8 +21,8 @@ export type GanttViewProps = {
 };
 
 const LEFT_COL_WIDTH = '240px';
-const ROW_HEIGHT = '52px';
-const ROW_HEIGHT_PX = '52';
+const ROW_HEIGHT = '58px';
+const ROW_HEIGHT_PX = '58';
 const INITIAL_PAD_DAYS = 90;
 const EDGE_THRESHOLD_PX = 200;
 const EXTEND_DAYS = 60;


### PR DESCRIPTION
## Summary
간트 화면을 SPEC §7 G-4 와 시각적으로 일치시킴.

1. **좌측 컬럼 헤더에 `작업` / `진행률` 라벨** 추가 (기존: 빈 Box)
2. **행 높이 36px → 58px** — 목록 task 행과 시각적으로 동일

## Before / After

### 좌측 헤더
| | Before | After |
|---|---|---|
| 좌측 컬럼 첫 행 | 빈 Box (라벨 없음) | `작업` (좌) / `진행률` (우) |

### 행 높이 (목록 ↔ 간트 일치)
| | 목록 행 | 간트 행 (Before) | 간트 행 (After) |
|---|---|---|---|
| 행 높이 | **58px** (실측) | 36px | **58px** |

## 변경

`components/gantt-view.tsx`
- `ROW_HEIGHT` `'36px'` → `'58px'` + 회귀 가드용 `ROW_HEIGHT_PX = '58'`
- 좌측 컬럼 빈 헤더 → `<Flex>` 라벨 행 (작업 행과 동일 컬럼 폭, `color="fg.muted"` `fontWeight="medium"` `fontSize="sm"`)
- 좌·우 헤더 + 좌·우 행 6개 모두 `data-row-height-px="58"` 회귀 가드

`components/__tests__/gantt-view.test.tsx`
- RED 1: 좌측 헤더에 `작업` / `진행률` 라벨 (`screen.getByText`)
- RED 2: `[data-row-height-px]` 갖는 모든 요소가 `"58"` 값

## Test plan
- [x] RED 2건 → GREEN, 기존 회귀 0
- [x] 유닛 170 / 통합 42 / tsc / lint 깨끗
- [x] Playwright 시각 검증
  - 목록 task 행 = 58px (실측)
  - 간트 좌·우 헤더 + 행 6개 모두 = 58px
  - 좌측 헤더에 `작업` / `진행률` 라벨 표시
  - 막대 / today line / "일정 없음" 텍스트 모두 새 높이에서 중앙 정렬 유지

## 영향 범위

- `gantt-bar.tsx`: 부모 행의 `position: relative` + `top: 50%` `translateY(-50%)` 로 자동 중앙 정렬 → 코드 변경 없음
- today line: `top: 0 bottom: 0` 으로 행 전체 따라감 → 영향 없음
- 모드 토글 / "오늘" 버튼 / 무한 스크롤: 변동 없음
- ARIA / 키보드: 변동 없음

## 범위 밖

- 목록 ↔ 간트 행 간격 일치 — 간트는 막대/오늘선 absolute 위치 때문에 flush 유지
- 좌측 헤더에 추가 컬럼 라벨 (담당자/상태 등) — SPEC 목업이 작업/진행률만 표시
- 목록 화면 변경

Closes #35

🤖 Generated with [Claude Code](https://claude.com/claude-code)
