### PR TITLE
fix: #39 간트 "일정 없음" 가로 스크롤 시 viewport 중앙 고정

### DIFF
--- a/components/__tests__/gantt-bar.test.tsx
+++ b/components/__tests__/gantt-bar.test.tsx
@@ -155,4 +155,14 @@ describe('<GanttBar />', () => {
       expect(empty?.textContent).toMatch(/일정 없음/);
     });
   });
+
+  describe('"일정 없음" 가로 스크롤 시 viewport 중앙 (#39)', () => {
+    it('빈 상태 wrapper 가 data-sticky-center="true" attribute 보유', () => {
+      const { container } = renderWithChakra(
+        <GanttBar startDate={null} dueDate={null} progress={0} epoch={epoch} pxPerDay={ppd} />,
+      );
+      const empty = container.querySelector('[data-testid="gantt-empty"]');
+      expect(empty?.getAttribute('data-sticky-center')).toBe('true');
+    });
+  });
 });

--- a/components/gantt-bar.tsx
+++ b/components/gantt-bar.tsx
@@ -21,15 +21,19 @@ export function GanttBar({
   overdue = false,
 }: GanttBarProps) {
   // SPEC §7 G-2: 시작일/목표 기한 중 하나라도 비면 막대 없이 "— 일정 없음 —" 표기.
+  // CSS sticky 로 가로 스크롤해도 viewport 중앙에 고정 (#39).
   if (!startDate || !dueDate) {
     return (
       <Box
-        position="absolute"
-        inset="0"
-        display="flex"
+        position="sticky"
+        left="50%"
+        h="100%"
+        display="inline-flex"
         alignItems="center"
-        justifyContent="center"
+        whiteSpace="nowrap"
+        style={{ transform: 'translateX(-50%)' }}
         data-testid="gantt-empty"
+        data-sticky-center="true"
       >
         <Text fontSize="sm" color="fg.muted">
           — 일정 없음 —


### PR DESCRIPTION
## Summary
간트의 시작일/기한이 비어 있는 행의 "— 일정 없음 —" 텍스트를 가로 스크롤해도 viewport 중앙에 계속 보이도록 수정.

## Before / After

| | Before | After |
|---|---|---|
| 빈 텍스트 위치 | 행 전체 폭(`totalWidthPx`) 의 가운데 — 스크롤 시 viewport 밖으로 사라짐 | viewport 가운데 (CSS `position: sticky`) — 스크롤해도 항상 보임 |

## 구현

`components/gantt-bar.tsx` 빈 상태 분기 wrapper:

```tsx
<Box
  position="sticky"
  left="50%"
  h="100%"
  display="inline-flex"
  alignItems="center"
  whiteSpace="nowrap"
  style={{ transform: 'translateX(-50%)' }}
  data-testid="gantt-empty"
  data-sticky-center="true"
>
  <Text>— 일정 없음 —</Text>
</Box>
```

- `position: sticky; left: 50%` → wrapper 의 left edge 가 scroll container 의 50% 위치(=viewport 가운데)에 고정
- `transform: translateX(-50%)` → wrapper 자체의 가운데가 그 지점에 옴
- `inline-flex` + `whiteSpace: nowrap` → wrapper 가 텍스트 폭만 슈링크-랩 (전체 row 폭 차지 안 함)
- CSS-only — scroll 이벤트마다 re-render 없음

## Test plan
- [x] RED 1 → GREEN: `data-sticky-center="true"` 가드
- [x] 유닛 175 / 통합 42 / tsc / lint 깨끗
- [x] Playwright 측정
  - 초기: scrollLeft=404, viewport center=720, empty center=720, **delta=0** ✓
  - 우측 끝(scrollLeft=799): **delta=0** ✓
  - 좌측 끝 부근(스크롤 확장 후 scrollLeft=515): **delta=0** ✓
  - 스크린샷 `gantt-empty-sticky-center.png` — 3개 빈 행 모두 viewport 중앙 정렬

## 영향 범위

- 막대 분기 (시작일+기한 둘 다 있음): 변동 없음
- 일정 없음 텍스트 자체(문구·색·폰트): 변동 없음
- 행 높이 / 부모 row 의 `position: relative`: 변동 없음
- 헤더 sticky (`position: sticky; top: 0`) 와 충돌 없음 (다른 축)
- 펼침/접힘 / 모드 토글 / 무한 스크롤: 변동 없음

## 범위 밖

- JS scroll 추적 폴백 — 모던 브라우저 sticky 안정 지원이라 불필요
- 좌측 트리 / 우측 헤더 / 막대 정렬 — 영향 없음

Closes #39

🤖 Generated with [Claude Code](https://claude.com/claude-code)
