### PR TITLE
fix: #41 간트 가로 스크롤 prepend 시 시각적 점프 제거

### DIFF
--- a/components/__tests__/gantt-view.test.tsx
+++ b/components/__tests__/gantt-view.test.tsx
@@ -213,6 +213,31 @@ describe('<GanttView />', () => {
       expect(scroller.scrollLeft).toBeCloseTo(todayPx - scroller.clientWidth / 2, 1);
     });
 
+    it('좌측 스크롤로 past prepend → scrollLeft 가 같은 사이클에서 deltaPx 만큼 보정 (#41)', () => {
+      const t = makeTask({
+        id: 'a',
+        title: 'X',
+        startDate: '2026-05-01',
+        dueDate: '2026-05-31',
+      });
+      const now = new Date('2026-05-14T00:00:00Z');
+      const { container } = renderWithChakra(<GanttView tasks={[t]} now={now} />);
+      const scroller = container.querySelector('[data-mode]') as HTMLElement;
+      const ppd = Number(scroller.getAttribute('data-px-per-day'));
+      const beforeTotalDays = Number(scroller.getAttribute('data-total-days'));
+      // scrollLeft 를 nearLeft 임계값(200) 이하로 설정 후 scroll 이벤트 발화.
+      Object.defineProperty(scroller, 'scrollLeft', {
+        configurable: true,
+        writable: true,
+        value: 50,
+      });
+      fireEvent.scroll(scroller);
+      // useLayoutEffect 가 같은 사이클에서 동기 보정 → totalDays +60, scrollLeft += 60*ppd
+      const afterTotalDays = Number(scroller.getAttribute('data-total-days'));
+      expect(afterTotalDays).toBe(beforeTotalDays + 60);
+      expect(scroller.scrollLeft).toBeCloseTo(50 + 60 * ppd, 0);
+    });
+
     it('모드 토글 시 오늘이 viewport 중앙으로 자동 스크롤 (#31 요청 사항)', () => {
       const t = makeTask({
         id: 'a',

--- a/components/gantt-view.tsx
+++ b/components/gantt-view.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect, useMemo, useRef, useState } from 'react';
+import { useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
 import { Box, Button, Flex, Text } from '@chakra-ui/react';
 import type { Task } from '@/lib/db/schema';
 import {
@@ -93,6 +93,21 @@ export function GanttView({ tasks, now = new Date() }: GanttViewProps) {
   const lastCenteredNonceRef = useRef<number>(0);
   const [centerNonce, setCenterNonce] = useState(0);
   const goToToday = () => setCenterNonce((n) => n + 1);
+
+  // #41 무한 스크롤 prepend 시 시각적 점프 제거:
+  // - extendingRef: burst 안 동시 prepend 방지 락
+  // - pendingPrependPxRef: prepend 한 px 누적
+  // - useLayoutEffect 가 paint 이전 동기 scrollLeft 보정
+  const extendingRef = useRef(false);
+  const pendingPrependPxRef = useRef(0);
+  useLayoutEffect(() => {
+    if (!extendingRef.current) return;
+    if (pendingPrependPxRef.current > 0 && scrollerRef.current) {
+      scrollerRef.current.scrollLeft += pendingPrependPxRef.current;
+      pendingPrependPxRef.current = 0;
+    }
+    extendingRef.current = false;
+  }, [range]);
 
   // 마운트 시 + 모드 변경 시 + "오늘" 클릭 시 today 를 viewport 중심으로.
   // 컨텐츠 폭이 viewport 보다 좁아 today 를 중앙에 둘 수 없으면
@@ -225,22 +240,19 @@ export function GanttView({ tasks, now = new Date() }: GanttViewProps) {
         data-epoch-iso={range.epoch.toISOString()}
         data-total-days={String(range.totalDays)}
         onScroll={(e) => {
+          if (extendingRef.current) return; // burst 중 동시 prepend 방지
           const el = e.currentTarget;
           const nearLeft = el.scrollLeft < EDGE_THRESHOLD_PX;
           const nearRight =
             el.scrollWidth - (el.scrollLeft + el.clientWidth) < EDGE_THRESHOLD_PX;
           if (nearLeft) {
-            const out = extendRange(range, 'past', EXTEND_DAYS);
-            setRange(out.range);
-            // 시각적 점프 방지 — prepend 한 만큼 scrollLeft 보정.
-            requestAnimationFrame(() => {
-              if (scrollerRef.current) {
-                scrollerRef.current.scrollLeft += out.deltaDaysAtStart * ppd;
-              }
-            });
+            extendingRef.current = true;
+            // 다음 사이클의 useLayoutEffect 가 paint 이전 scrollLeft 를 동기 보정.
+            pendingPrependPxRef.current += EXTEND_DAYS * ppd;
+            setRange((prev) => extendRange(prev, 'past', EXTEND_DAYS).range);
           } else if (nearRight) {
-            const out = extendRange(range, 'future', EXTEND_DAYS);
-            setRange(out.range);
+            extendingRef.current = true;
+            setRange((prev) => extendRange(prev, 'future', EXTEND_DAYS).range);
           }
         }}
       >


### PR DESCRIPTION
## Summary
간트 좌측 가로 스크롤로 인한 past prepend (60일 추가) 시 한 프레임 동안 콘텐츠가 우측으로 밀린 채 보이던 시각적 점프를 제거.

## 원인 (3가지 결합)

1. **rAF 타이밍** — `setRange` → re-render → DOM commit → **paint** → `rAF` (보정) → paint 와 보정 사이 1 프레임 차가 사용자에게 점프로 보임
2. **Stale closure** — 동일 burst 의 여러 scroll 이벤트가 클로저의 stale `range` 로 `extendRange` 계산 → 중복/과잉 prepend 가능
3. **중복 트리거** — 한 burst 의 여러 이벤트가 모두 `nearLeft` 만족 시 보정 호출 누적/누락

## 해결 (3가지 한꺼번에)

### 1. `requestAnimationFrame` → `useLayoutEffect`
DOM mutation 직후 / **paint 이전** 에 동기 실행. 보정과 paint 가 같은 사이클 안에 일어나 어긋난 상태가 사용자에게 노출되는 프레임 0.

### 2. 함수형 `setRange`
`setRange((prev) => extendRange(prev, ...).range)` — 항상 최신 range 입력.

### 3. `extendingRef` 락
burst 안 동시 prepend 1번으로 제한, useLayoutEffect 보정 완료 후 해제.

## 변경

`components/gantt-view.tsx`
- `useLayoutEffect` import 추가
- 신규 ref: `extendingRef`, `pendingPrependPxRef`
- 신규 `useLayoutEffect([range])`: 락이 켜진 상태에서만 동작, `pendingPrependPxRef` 만큼 `scrollLeft` 동기 보정
- `onScroll`: rAF 제거 → 함수형 `setRange` + ref 누적
- nearRight (future) 도 락 적용 (보정은 불필요)

`components/__tests__/gantt-view.test.tsx`
- RED 1: 좌측 prepend 시 같은 사이클에서 `totalDays + 60` 과 `scrollLeft += 60*ppd` 동기 보정

## Test plan
- [x] RED 1 → GREEN
- [x] 유닛 176 / 통합 42 / tsc / lint 깨끗
- [x] Playwright 측정
  - 초기: scrollLeft=0, totalDays=180, epoch=2026-01-27
  - scrollLeft=50 으로 좌측 끝 근처 → onScroll → past extension 트리거
  - **즉시** 측정: scrollLeft=565, totalDays=240(+60), epoch=2025-11-28(-60일)
  - 보정 정확: 50 + 60*8.5714 ≈ 565 ✓
  - 같은 날짜의 mark 가 viewport 동일 좌표에 유지 (e.g. 5/4 mark 가 781px 동일 위치)

## 영향 범위

- centering useEffect (mode 토글 / "오늘" 버튼): 가드(`!ppdChanged && !nonceChanged`) 로 새 useLayoutEffect 와 충돌 없음
- "일정 없음" sticky / 펼침/접힘 / 라벨 포맷: 변동 없음
- 우측(future) 확장: 보정 불필요 — 락만 적용해 burst 중복 방지

## 범위 밖

- 스크롤 throttle / debounce — 락만으로 충분
- onScroll 핸들러 useCallback 화 — 측정상 영향 미미

Closes #41

🤖 Generated with [Claude Code](https://claude.com/claude-code)
